### PR TITLE
Add install_requires entries for 'pip install' to install deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ latexcodec==1.0.5
 
 # for robocrystallographer
 matminer>=0.5.0
-robocrys
+robocrys>=0.1.3
 
 # for propnet
 https://github.com/materialsintelligence/propnet/archive/master.zip

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,15 @@ with open(os.path.join('crystal_toolkit', 'package.json')) as f:
 
 package_name = package["name"].replace(" ", "_").replace("-", "_")
 
+
+def requirements(fname):
+    with open(fname, 'r') as f:
+        reqs = f.read().splitlines()
+    reqs = [r.strip().split()[0] for r in reqs if r.strip() and not r.strip().startswith('#')]
+    reqs = [r.replace('==', '>=') for r in reqs if '>=' in r or '==' in r]
+    return reqs
+
+
 setup(
     name=package_name,
     version=package["version"],
@@ -16,5 +25,5 @@ setup(
     include_package_data=True,
     license=package['license'],
     description=package['description'] if 'description' in package else package_name,
-    install_requires=[]
+    install_requires=requirements('requirements.txt'),
 )

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,5 @@ setup(
     license=package['license'],
     description=package['description'] if 'description' in package else package_name,
     install_requires=requirements('requirements.txt'),
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
This is required e.g. to load [`emmet.materials.visualization`](https://github.com/materialsproject/emmet/blob/be68992e4e4ccdb638fa6274b4b340d7a717d881/emmet/materials/visualization.py), ensuring that installing this package installs its dependencies.