### PR TITLE
Use local `babel` for `npm run` cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build:js": "webpack --mode production",
     "build:py": "dash-generate-components ./src/lib/components crystal_toolkit",
     "build:py-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:py)",
-    "build:amd": "babel --plugins transform-es2015-modules-amd ./src/lib/components/Simple3DScene.js > ./src/lib/components/Simple3DScene.amd.js",
+    "build:amd": "./node_modules/.bin/babel --plugins transform-es2015-modules-amd ./src/lib/components/Simple3DScene.js > ./src/lib/components/Simple3DScene.amd.js",
     "build:all": "npm run build:js && npm run build:js-dev && npm run build:py && npm run build:amd",
     "build:all-activated": "(. venv/bin/activate || venv\\scripts\\activate && npm run build:all)"
   },


### PR DESCRIPTION
Ensures `transform-es2015-modules-amd` plugin is known.