### PR TITLE
Band structure component update

### DIFF
--- a/jupyterlab-extension/package-lock.json
+++ b/jupyterlab-extension/package-lock.json
@@ -13,55 +13,55 @@
       }
     },
     "@babel/generator": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
-      "integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.17.tgz",
+      "integrity": "sha512-DSA7ruZrY4WI8VxuS1jWSRezFnghEoYEFrZcw9BizQRmOZiUsiHl59+qEARGPqPikwA/GPTyRCi7isuCK/oyqg==",
       "requires": {
-        "@babel/types": "^7.12.11",
+        "@babel/types": "^7.12.17",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
-      "integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz",
+      "integrity": "sha512-7YXfX5wQ5aYM/BOlbSccHDbuXXFPxeoUmfWtz8le2yTkTZc+BxsiEnENFoi2SlmA8ewDkG2LgIMIVzzn2h8kfw==",
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
-      "integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
       "requires": {
-        "@babel/helper-get-function-arity": "^7.12.10",
-        "@babel/template": "^7.12.7",
-        "@babel/types": "^7.12.11"
+        "@babel/helper-get-function-arity": "^7.12.13",
+        "@babel/template": "^7.12.13",
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.12.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
-      "integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+      "integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
       "requires": {
-        "@babel/types": "^7.12.10"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-      "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
+      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
       "requires": {
-        "@babel/types": "^7.12.5"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
-      "integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+      "integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
       "requires": {
-        "@babel/types": "^7.12.11"
+        "@babel/types": "^7.12.13"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -80,63 +80,88 @@
       }
     },
     "@babel/parser": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
-      "integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg=="
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.17.tgz",
+      "integrity": "sha512-r1yKkiUTYMQ8LiEI0UcQx5ETw5dpTLn9wijn9hk6KkTtOK95FndDN10M+8/s6k/Ymlbivw0Av9q4SlgF80PtHg=="
     },
     "@babel/runtime": {
-      "version": "7.12.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
-      "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/template": {
-      "version": "7.12.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
-      "integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+      "integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
       "requires": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/parser": "^7.12.7",
-        "@babel/types": "^7.12.7"
+        "@babel/code-frame": "^7.12.13",
+        "@babel/parser": "^7.12.13",
+        "@babel/types": "^7.12.13"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+          "requires": {
+            "@babel/highlight": "^7.12.13"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
-      "integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.17.tgz",
+      "integrity": "sha512-LGkTqDqdiwC6Q7fWSwQoas/oyiEYw6Hqjve5KOSykXkmFJFqzvGMb9niaUEag3Rlve492Mkye3gLw9FTv94fdQ==",
       "requires": {
-        "@babel/code-frame": "^7.12.11",
-        "@babel/generator": "^7.12.11",
-        "@babel/helper-function-name": "^7.12.11",
-        "@babel/helper-split-export-declaration": "^7.12.11",
-        "@babel/parser": "^7.12.11",
-        "@babel/types": "^7.12.12",
+        "@babel/code-frame": "^7.12.13",
+        "@babel/generator": "^7.12.17",
+        "@babel/helper-function-name": "^7.12.13",
+        "@babel/helper-split-export-declaration": "^7.12.13",
+        "@babel/parser": "^7.12.17",
+        "@babel/types": "^7.12.17",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+        "@babel/code-frame": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+          "integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
           "requires": {
-            "ms": "2.1.2"
+            "@babel/highlight": "^7.12.13"
           }
         },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        "@babel/highlight": {
+          "version": "7.12.13",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.12.13.tgz",
+          "integrity": "sha512-kocDQvIbgMKlWxXe9fof3TQ+gkIPOUSEYhJjqUjvKMez3krV7vbzYCDq39Oj11UAVK7JqPVGQPlgE85dPNlQww==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.12.11",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
         }
       }
     },
     "@babel/types": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+      "version": "7.12.17",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.17.tgz",
+      "integrity": "sha512-tNMDjcv/4DIcHxErTgwB9q2ZcYyN0sUfgGKUK/mm1FJK7Wz+KstoEekxrl/tBiNDgLK1HGi+sppj1An/1DR4fQ==",
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
         "lodash": "^4.17.19",
@@ -148,14 +173,6 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz",
       "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
       "dev": true
-    },
-    "@egjs/hammerjs": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
-      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
-      "requires": {
-        "@types/hammerjs": "^2.0.36"
-      }
     },
     "@emotion/cache": {
       "version": "10.0.29",
@@ -222,9 +239,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "2.6.14",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+          "version": "2.6.15",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.15.tgz",
+          "integrity": "sha512-FNeiVKudquehtR3t9TRRnsHL+lJhuHF5Zn9dt01jpojlurLEPDhhEtUkWmAUJ7/fOLaLG4dCDEnUsR0N1rZSsg=="
         }
       }
     },
@@ -835,64 +852,66 @@
       }
     },
     "@materialsproject/mp-react-components": {
-      "version": "0.1.4-SNAPSHOT.1608233645",
-      "resolved": "https://registry.npmjs.org/@materialsproject/mp-react-components/-/mp-react-components-0.1.4-SNAPSHOT.1608233645.tgz",
-      "integrity": "sha512-+uX3fzSscWt2a9isX/HaGyKE4avFnq069Qg9dMFl4lDOBS7WX8FCjlW8zacWidjpOKyzJmQjJYjC6p+Dsx8jpg==",
+      "version": "0.1.8-SNAPSHOT.1612288568",
+      "resolved": "https://registry.npmjs.org/@materialsproject/mp-react-components/-/mp-react-components-0.1.8-SNAPSHOT.1612288568.tgz",
+      "integrity": "sha512-+IT2RC2te15a9shH805yJ8BWhTjjnAtivoSelEx8alw1yYan4c2+kDGRbrTUFIr/x16T9a01HxRbmsqKPG9D7A==",
       "requires": {
-        "@s-ui/react-molecule-button-group": "^2.1.0",
-        "@storybook/client-api": "^5.3.18",
+        "@s-ui/react-molecule-button-group": "^2.3.0",
+        "@storybook/client-api": "^5.3.21",
         "@trendmicro/react-dropdown": "^1.4.0",
         "@types/classnames": "^2.2.11",
-        "@welldone-software/why-did-you-render": "^4.1.0-alpha.1",
-        "@zendeskgarden/react-buttons": "^8.5.0",
-        "@zendeskgarden/react-theming": "^8.5.0",
+        "@welldone-software/why-did-you-render": "^4.3.2",
+        "@zendeskgarden/react-buttons": "^8.29.1",
+        "@zendeskgarden/react-theming": "^8.29.1",
         "add": "^2.0.6",
-        "axios": "^0.19.2",
-        "axios-hooks": "^1.10.0",
+        "axios": "^0.21.1",
+        "axios-hooks": "^1.11.0",
+        "base64-js": "^1.5.1",
         "bulma": "^0.9.1",
         "bulma-tooltip": "^3.0.2",
         "classnames": "^2.2.6",
         "components": "^0.1.0",
         "copy-to-clipboard": "^3.3.1",
-        "css-loader": "^3.4.2",
+        "css-loader": "^3.6.0",
         "d3": "^5.15.0",
-        "less-loader": "^6.1.0",
+        "less-loader": "^6.2.0",
+        "msw": "^0.25.0",
         "prop-types": "^15.7.2",
         "qs": "^6.9.4",
         "querystring": "^0.2.0",
-        "rc-checkbox": "^2.2.0",
-        "react": "^16.13.1",
-        "react-aria-menubutton": "^7.0.0",
+        "rc-checkbox": "^2.3.2",
+        "react": "^16.14.0",
+        "react-aria-menubutton": "^7.0.1",
         "react-bulma-components": "^3.4.0",
         "react-compound-slider": "^2.5.0",
-        "react-data-table-component": "^6.11.5",
+        "react-data-table-component": "^6.11.6",
         "react-dnd": "^10.0.2",
         "react-dnd-html5-backend": "^10.0.2",
-        "react-dom": "^16.13.1",
+        "react-dom": "^16.14.0",
         "react-graph-vis": "^1.0.5",
         "react-hook-form": "^5.4.2",
-        "react-icons": "^3.9.0",
+        "react-icons": "^3.11.0",
         "react-json-view": "^1.19.1",
         "react-latex": "^1.6.0",
         "react-loader-spinner": "^3.1.14",
         "react-masonry-css": "^1.0.14",
-        "react-number-format": "^4.4.1",
-        "react-range": "^1.8.3",
-        "react-responsive": "^8.0.3",
+        "react-number-format": "^4.4.3",
+        "react-range": "^1.8.5",
+        "react-responsive": "^8.2.0",
         "react-router-dom": "^5.2.0",
-        "react-select": "^3.1.0",
+        "react-select": "^3.1.1",
         "react-svg-morph": "^0.2.1",
         "react-switch": "^5.0.1",
-        "react-toastify": "^5.5.0",
-        "react-tooltip": "^4.2.3",
-        "react-window": "^1.8.5",
-        "rxjs": "^6.5.4",
-        "style-loader": "^1.1.2",
-        "styled-components": "^5.1.0",
+        "react-toastify": "^6.2.0",
+        "react-tooltip": "^4.2.11",
+        "react-window": "^1.8.6",
+        "rxjs": "^6.6.3",
+        "style-loader": "^1.3.0",
+        "styled-components": "^5.2.1",
         "svgtodatauri": "0.0.0",
         "three": "^0.115.0",
-        "ts-debounce": "^2.0.1",
-        "use-deep-compare-effect": "^1.4.0",
+        "ts-debounce": "^2.1.0",
+        "use-deep-compare-effect": "^1.6.1",
         "utils": "^0.3.1",
         "uuid": "^8.3.2",
         "xlsx": "^0.15.6"
@@ -932,6 +951,11 @@
       "requires": {
         "mkdirp": "^1.0.4"
       }
+    },
+    "@open-draft/until": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-1.0.3.tgz",
+      "integrity": "sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q=="
     },
     "@reach/router": {
       "version": "1.3.4",
@@ -987,9 +1011,9 @@
       }
     },
     "@s-ui/theme": {
-      "version": "8.88.0",
-      "resolved": "https://registry.npmjs.org/@s-ui/theme/-/theme-8.88.0.tgz",
-      "integrity": "sha512-QPwDpq5jytcT6arV7uAhJ4lembzC27v3Ca0qZYF1Dpmv7/1iu9TwQjiVsaCOW5l6vWNKqtjAUGFhAW/s5kQvpg=="
+      "version": "8.93.0",
+      "resolved": "https://registry.npmjs.org/@s-ui/theme/-/theme-8.93.0.tgz",
+      "integrity": "sha512-dv0+E47OqA4DnUj5s1Ht5IP4XUCWFhaA0pq16fmzETe9MJGmTup7oanjfbWnRduySVmey7IJbfgpPvx2fI07PA=="
     },
     "@schibstedspain/rosetta": {
       "version": "3.10.2",
@@ -1213,6 +1237,11 @@
       "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz",
       "integrity": "sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw=="
     },
+    "@types/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg=="
+    },
     "@types/eslint": {
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.6.tgz",
@@ -1254,16 +1283,6 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
-    },
-    "@types/hammerjs": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
-      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
-    },
-    "@types/history": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
-      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
     },
     "@types/hoist-non-react-statics": {
       "version": "3.3.1",
@@ -1307,18 +1326,17 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/reach__router": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.6.tgz",
-      "integrity": "sha512-RHYataCUPQnt+GHoASyRLq6wmZ0n8jWlBW8Lxcwd30NN6vQfbmTeoSDfkgxO0S1lEzArp8OFDsq5KIs7FygjtA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.7.tgz",
+      "integrity": "sha512-cyBEb8Ef3SJNH5NYEIDGPoMMmYUxROatuxbICusVRQIqZUB85UCt6R2Ok60tKS/TABJsJYaHyNTW3kqbpxlMjg==",
       "requires": {
-        "@types/history": "*",
         "@types/react": "*"
       }
     },
     "@types/react": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.0.tgz",
-      "integrity": "sha512-aj/L7RIMsRlWML3YB6KZiXB3fV2t41+5RBGYF8z+tAKU43Px8C3cYUZsDvf1/+Bm4FK21QWBrDutu8ZJ/70qOw==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz",
+      "integrity": "sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1638,62 +1656,63 @@
       "dev": true
     },
     "@zendeskgarden/container-buttongroup": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-buttongroup/-/container-buttongroup-0.3.7.tgz",
-      "integrity": "sha512-u11GgTt+hC3wBlBSq5a9BDAo7zm0sutPB11HAGk3OmiQ4BcrcG44Jiuot02lzDiG2X1EDFFHSo91QDPqzc0Fgw==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-buttongroup/-/container-buttongroup-0.3.8.tgz",
+      "integrity": "sha512-EeuRBUURRH8J/Euteb/eMXMSxZTuTBeaiHTOVHc69l+HfwdG1NMa2UfAP3TmSqnFzD8sJa2asaCe96gP98sYqQ==",
       "requires": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-selection": "^1.3.7"
+        "@zendeskgarden/container-selection": "^1.3.8"
       }
     },
     "@zendeskgarden/container-focusvisible": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.5.tgz",
-      "integrity": "sha512-cFCdDHda8s50oXVY7yqf1ZBI+n0HR2wvbVK604SX+BV9U/KYkkqvNWxZ46SCppLG7b8O7DG4XpzUPow1VPOS/A==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-focusvisible/-/container-focusvisible-0.4.6.tgz",
+      "integrity": "sha512-YLGJ2+i9PKzP4ND9OtuWrUomJvKp+Mel8QSIGsWkUQ6DqabVZPi2//BZ0slqnyq4LcIS0MjTSCLi28H6IFjrrA==",
       "requires": {
         "@babel/runtime": "^7.8.4"
       }
     },
     "@zendeskgarden/container-keyboardfocus": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.6.tgz",
-      "integrity": "sha512-n20dXQC+aeyAU1ROzw3I1SQ8072xfkhxIBzNTSogZVbNUYbhOw269EyMQRxSqzesUMNX19nWZqoGf2Wv1+ke2w==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-keyboardfocus/-/container-keyboardfocus-0.4.7.tgz",
+      "integrity": "sha512-eJRUx3T895SoEqFX5R3zt8qz+ZHxinTAjyj0nNGMR3r+aqx8LjZrAq4hCFo8dafO6VF2IuO3pn3Ss44y585z/A==",
       "requires": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-utilities": "^0.5.4"
+        "@zendeskgarden/container-utilities": "^0.5.5"
       }
     },
     "@zendeskgarden/container-selection": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-selection/-/container-selection-1.3.7.tgz",
-      "integrity": "sha512-Q7xrkpJJG9o0pfsaVAOPVJaxYCchbU9yvCvuwWc11IT+UbV2SVidQ/uPa9/BOmmfBJ7vatg/bOrrHNG7T/4dKw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-selection/-/container-selection-1.3.8.tgz",
+      "integrity": "sha512-e6xSGxrQOjbW1mh30nZCS9rRkfMWZvWowoXuAe0z0kfU4T+tRNRSZtFmWklb3jvLoFDvDdHja7HElYyDlBa+1g==",
       "requires": {
         "@babel/runtime": "^7.8.4",
-        "@zendeskgarden/container-utilities": "^0.5.4"
+        "@zendeskgarden/container-utilities": "^0.5.5"
       }
     },
     "@zendeskgarden/container-utilities": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-0.5.4.tgz",
-      "integrity": "sha512-Iz6YZ6va3JIShzKXKjK4TCf168GSX+/XeeBr6o9MTJ4K84lO0F0ZX2GIFuZmacfkBjCXfyNxj4aua/5/1ZXyPg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/container-utilities/-/container-utilities-0.5.5.tgz",
+      "integrity": "sha512-41qrK/ePXbPD+t2bKOtbzIZAjIlrIcN7EVGShPAjMjRzhQpZeX5UFsIrmN56/vQ8+xMVh/BxNEXgbtAO37FgwA==",
       "requires": {
         "@babel/runtime": "^7.8.4"
       }
     },
     "@zendeskgarden/react-buttons": {
-      "version": "8.29.1",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-buttons/-/react-buttons-8.29.1.tgz",
-      "integrity": "sha512-AiZVmat2y59T1mYueqMKxtRwHHrN12PjBR0Z0cWsk0QQgDt43t5OCOv5mNbu0GLdnG4MXjnPqrljg9LZ8ThOOA==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-buttons/-/react-buttons-8.32.1.tgz",
+      "integrity": "sha512-lzYBCX6NwodXU1sgKN945SqDwYqVMeO1n/qIy7uea3507EWCNlE3uAFbn4PBL+LvOPbPyOVjPWJfCHWekSpjAg==",
       "requires": {
-        "@zendeskgarden/container-buttongroup": "^0.3.1",
-        "@zendeskgarden/container-keyboardfocus": "^0.4.1",
-        "polished": "^4.0.0"
+        "@zendeskgarden/container-buttongroup": "^0.3.8",
+        "@zendeskgarden/container-keyboardfocus": "^0.4.7",
+        "polished": "^4.0.0",
+        "prop-types": "^15.5.7"
       },
       "dependencies": {
         "polished": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/polished/-/polished-4.0.5.tgz",
-          "integrity": "sha512-BY2+LVtOHQWBQpGN4GPAKpCdsBePOdSdHTpZegRDRCrvGPkRPTx1DEC+vGjIDPhXS7W2qiBxschnwRWTFdMZag==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.1.tgz",
+          "integrity": "sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==",
           "requires": {
             "@babel/runtime": "^7.12.5"
           }
@@ -1701,19 +1720,20 @@
       }
     },
     "@zendeskgarden/react-theming": {
-      "version": "8.29.1",
-      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-theming/-/react-theming-8.29.1.tgz",
-      "integrity": "sha512-ahDNWonkTQaXQVAWd1XX7b7VWFPmit+sWRoUldOIkFguy8fHG0rHGCJ9piBwk3SuDVNy5sJpbES94Q/Wq9gH2Q==",
+      "version": "8.32.1",
+      "resolved": "https://registry.npmjs.org/@zendeskgarden/react-theming/-/react-theming-8.32.1.tgz",
+      "integrity": "sha512-5bz2gGy+5zF5WGuR7zADjLug1nd+rLnTm0Ni9bpzWx2pwQPWk7R6bI8Jv4qjiea7KUR+Wol2D9qHsLCz92mYpA==",
       "requires": {
-        "@zendeskgarden/container-focusvisible": "^0.4.3",
-        "@zendeskgarden/container-utilities": "^0.5.1",
-        "polished": "^4.0.0"
+        "@zendeskgarden/container-focusvisible": "^0.4.6",
+        "@zendeskgarden/container-utilities": "^0.5.5",
+        "polished": "^4.0.0",
+        "prop-types": "^15.5.7"
       },
       "dependencies": {
         "polished": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/polished/-/polished-4.0.5.tgz",
-          "integrity": "sha512-BY2+LVtOHQWBQpGN4GPAKpCdsBePOdSdHTpZegRDRCrvGPkRPTx1DEC+vGjIDPhXS7W2qiBxschnwRWTFdMZag==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/polished/-/polished-4.1.1.tgz",
+          "integrity": "sha512-4MZTrfPMPRLD7ac8b+2JZxei58zw6N1hFkdBDERif5Tlj19y3vPoPusrLG+mJIlPTGnUlKw3+yWz0BazvMx1vg==",
           "requires": {
             "@babel/runtime": "^7.12.5"
           }
@@ -1810,8 +1830,7 @@
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1838,6 +1857,15 @@
             "for-own": "^0.1.1"
           }
         }
+      }
+    },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "argparse": {
@@ -1930,11 +1958,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "axios-hooks": {
@@ -1957,9 +1985,9 @@
       }
     },
     "babel-plugin-emotion": {
-      "version": "10.0.33",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
-      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.2.2.tgz",
+      "integrity": "sha512-SMSkGoqTbTyUTDeuVuPIWifPdUGkTk1Kf9BWRiXIOIcuyMfsdp2EjeiiFvOzX8NOBvEh/ypKYvUh2rkgAJMCLA==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -2031,10 +2059,20 @@
       "resolved": "https://registry.npmjs.org/base16/-/base16-1.0.0.tgz",
       "integrity": "sha1-4pf2DX7BAUp6lxo568ipjAtoHnA="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2050,7 +2088,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -2075,9 +2112,9 @@
       "dev": true
     },
     "bulma": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.1.tgz",
-      "integrity": "sha512-LSF69OumXg2HSKl2+rN0/OEXJy7WFEb681wtBlNS/ulJYR27J3rORHibdXZ6GVb/vyUzzYK/Arjyh56wjbFedA=="
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/bulma/-/bulma-0.9.2.tgz",
+      "integrity": "sha512-e14EF+3VSZ488yL/lJH0tR8mFWiEQVCMi/BQUMi2TGMBOk+zrDg4wryuwm/+dRSHJw0gMawp2tsW7X1JYUCE3A=="
     },
     "bulma-tooltip": {
       "version": "3.0.2",
@@ -2235,6 +2272,21 @@
       "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o=",
       "dev": true
     },
+    "chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      }
+    },
     "chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -2275,6 +2327,16 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
       "dev": true
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
     },
     "clone": {
       "version": "2.1.2",
@@ -2324,6 +2386,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+    },
     "codepage": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.14.0.tgz",
@@ -2370,11 +2437,6 @@
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
-    },
     "components": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/components/-/components-0.1.0.tgz",
@@ -2394,12 +2456,17 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
     "copy-anything": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.1.tgz",
-      "integrity": "sha512-lA57e7viQHOdPQcrytv5jFeudZZOXuyk47lZym279FiDQ8jeZomXiGuVf6ffMKkJ+3TIai3J1J3yi6M+/4U35g==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.3.tgz",
+      "integrity": "sha512-GK6QUtisv4fNS+XcI7shX0Gx9ORg7QqIznyfho79JTnX1XhLiyZHfftvGiziqzRiEi/Bjhgpi+D2o7HxJFPnDQ==",
       "requires": {
-        "is-what": "^3.7.1"
+        "is-what": "^3.12.0"
       }
     },
     "copy-to-clipboard": {
@@ -2411,9 +2478,9 @@
       }
     },
     "core-js": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
-      "integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A=="
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
+      "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ=="
     },
     "cosmiconfig": {
       "version": "6.0.0",
@@ -2443,6 +2510,14 @@
       "requires": {
         "gud": "^1.0.0",
         "warning": "^4.0.3"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -2508,9 +2583,9 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "csstype": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
     },
     "d3": {
       "version": "5.16.0",
@@ -2777,11 +2852,11 @@
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.2"
       }
     },
     "decompress-response": {
@@ -2929,8 +3004,7 @@
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "emojis-list": {
       "version": "3.0.0",
@@ -2945,24 +3019,6 @@
         "@babel/runtime": "^7.5.5",
         "@emotion/weak-memoize": "0.2.5",
         "hoist-non-react-statics": "^3.3.0"
-      }
-    },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
       }
     },
     "end-of-stream": {
@@ -3050,8 +3106,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -3463,33 +3518,31 @@
       }
     },
     "fbemitter": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-2.1.1.tgz",
-      "integrity": "sha1-Uj4U/a9SSIBbsC9i78M75wP1GGU=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbemitter/-/fbemitter-3.0.0.tgz",
+      "integrity": "sha512-KWKaceCwKQU0+HPoop6gn4eOHk50bBv/VxjJtGMfwmJt3D29JpN4H4eisCtIPA+a8GVBam+ldMMpMjJUvpDyHw==",
       "requires": {
-        "fbjs": "^0.8.4"
+        "fbjs": "^3.0.0"
       }
     },
     "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.0.tgz",
+      "integrity": "sha512-dJd4PiDOFuhe7vk4F80Mba83Vr2QuK86FoxtgPmzBqEJahncp+13YCmfoa53KHCo6OnlXLG7eeMWPfB5CrpVKg==",
       "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
+        "cross-fetch": "^3.0.4",
+        "fbjs-css-vars": "^1.0.0",
         "loose-envify": "^1.0.0",
         "object-assign": "^4.1.0",
         "promise": "^7.1.1",
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
       }
+    },
+    "fbjs-css-vars": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "figures": {
       "version": "3.2.0",
@@ -3536,7 +3589,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -3595,12 +3647,12 @@
       "dev": true
     },
     "flux": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/flux/-/flux-3.1.3.tgz",
-      "integrity": "sha1-0jvtUVp5oi2TOrU6tK2hnQWy8Io=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flux/-/flux-4.0.1.tgz",
+      "integrity": "sha512-emk4RCvJ8RzNP2lNpphKnG7r18q8elDYNAPx7xn+bDeOIo9FFfxEfIQ2y6YbQNmnsGD3nH1noxtLE64Puz1bRQ==",
       "requires": {
-        "fbemitter": "^2.0.0",
-        "fbjs": "^0.8.0"
+        "fbemitter": "^3.0.0",
+        "fbjs": "^3.0.0"
       }
     },
     "focus-group": {
@@ -3609,12 +3661,9 @@
       "integrity": "sha1-4PMu2GsNq91v/OvfiY7LMuR/7c4="
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      }
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "for-in": {
       "version": "0.1.8",
@@ -3668,6 +3717,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "optional": true
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3678,6 +3733,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
     "get-intrinsic": {
       "version": "1.0.2",
@@ -3729,7 +3789,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -3794,6 +3853,11 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
       "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
     },
+    "graphql": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+    },
     "gud": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
@@ -3821,6 +3885,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
       "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+    },
+    "headers-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/headers-utils/-/headers-utils-1.2.0.tgz",
+      "integrity": "sha512-4/BMXcWrJErw7JpM87gF8MNEXcIMLzepYZjNRv/P9ctgupl2Ywa3u1PgHtNhSRq84bHH9Ndlkdy7bSi+bZ9I9A=="
     },
     "history": {
       "version": "4.10.1",
@@ -4056,6 +4125,14 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -4089,14 +4166,12 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-function": {
       "version": "1.0.2",
@@ -4107,7 +4182,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -4155,11 +4229,6 @@
         "has-symbols": "^1.0.1"
       }
     },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
@@ -4169,9 +4238,9 @@
       }
     },
     "is-what": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.12.0.tgz",
-      "integrity": "sha512-2ilQz5/f/o9V7WRWJQmpFYNmQFZ9iM+OXRonZKcYgTkCzjb949Vi4h282PD1UfmgHk666rcWonbRJ++KI41VGw=="
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
+      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA=="
     },
     "isarray": {
       "version": "0.0.1",
@@ -4188,26 +4257,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
-      }
     },
     "jest-worker": {
       "version": "26.6.2",
@@ -4318,11 +4367,6 @@
       "requires": {
         "commander": "^2.19.0"
       }
-    },
-    "keycharm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.2.0.tgz",
-      "integrity": "sha1-+m6i5DuQpoAohD0n8gddNajD5vk="
     },
     "keyv": {
       "version": "3.1.0",
@@ -4783,9 +4827,74 @@
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "msw": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-0.25.0.tgz",
+      "integrity": "sha512-KWW9Qwf4ecw7lgf7KM0gRfFLvfmUPw0ljCvii2IluhObZggoN/dBMFe5YJf1utnW7q9qHBc4oMNLrd8zFE6BfQ==",
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "@types/cookie": "^0.4.0",
+        "chalk": "^4.1.0",
+        "chokidar": "^3.4.2",
+        "cookie": "^0.4.1",
+        "graphql": "^15.4.0",
+        "headers-utils": "^1.2.0",
+        "node-fetch": "^2.6.1",
+        "node-match-path": "^0.6.0",
+        "node-request-interceptor": "^0.6.3",
+        "statuses": "^2.0.0",
+        "strict-event-emitter": "^0.1.0",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -4827,6 +4936,11 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
+    "node-match-path": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/node-match-path/-/node-match-path-0.6.1.tgz",
+      "integrity": "sha512-5KjUxG0fUqiIB4HXVatTYGNXf0fD/ZIC88P2w5izFrk6jz45hgavoVuIERsTqb+lMPMuvvL3rxvFWwpnJzN/wQ=="
+    },
     "node-polyglot": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/node-polyglot/-/node-polyglot-0.4.3.tgz",
@@ -4837,6 +4951,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
       "integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
       "dev": true
+    },
+    "node-request-interceptor": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/node-request-interceptor/-/node-request-interceptor-0.6.3.tgz",
+      "integrity": "sha512-8I2V7H2Ch0NvW7qWcjmS0/9Lhr0T6x7RD6PDirhvWEkUQvy83x8BA4haYMr09r/rig7hcgYSjYh6cd4U7G1vLA==",
+      "requires": {
+        "@open-draft/until": "^1.0.3",
+        "debug": "^4.3.0",
+        "headers-utils": "^1.2.0",
+        "strict-event-emitter": "^0.1.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -5153,9 +5278,9 @@
       }
     },
     "parse-json": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -5207,8 +5332,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pidtree": {
       "version": "0.3.1",
@@ -5232,11 +5356,11 @@
       }
     },
     "polished": {
-      "version": "3.6.7",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.7.tgz",
-      "integrity": "sha512-b4OViUOihwV0icb9PHmWbR+vPqaSzSAEbgLskvb7ANPATVXGiYv/TQFHQo65S53WU9i5EQ1I03YDOJW7K0bmYg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.7.1.tgz",
+      "integrity": "sha512-/QgHrNGYwIA4mwxJ/7FSvalUJsm7KNfnXiScVSEG2Xa5qxDeBn4nmdjN2pW00mkM2Tts64ktc47U8F7Ed1BRAA==",
       "requires": {
-        "@babel/runtime": "^7.9.2"
+        "@babel/runtime": "^7.12.5"
       }
     },
     "postcss": {
@@ -5411,14 +5535,14 @@
       "integrity": "sha1-H+Bk+wrIUfDeYTIKi/eWg2Qi8z4="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg=="
     },
     "querystringify": {
       "version": "2.2.0",
@@ -5598,14 +5722,15 @@
       }
     },
     "react-graph-vis": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/react-graph-vis/-/react-graph-vis-1.0.5.tgz",
-      "integrity": "sha512-y7+eHcwj7GryRoY+ZawwsDmS8OMeJ8Gpzmzejqwz+T2qg6IYTk1bod42H5g3J2zzHcPaqAZpwxZG3d3YB4nBwQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-graph-vis/-/react-graph-vis-1.0.7.tgz",
+      "integrity": "sha512-FI35zlBMKU22JEvG1ukd1DDwW185y4YrDvHm6Bom9EGdA+UNMrZrIV/lyPIRWPcRkzbKaA1w1NvOYcRApD4KdQ==",
       "requires": {
         "lodash": "^4.17.15",
         "prop-types": "^15.5.10",
         "uuid": "^2.0.1",
-        "vis-network": "^5.1.1"
+        "vis-data": "^7.1.2",
+        "vis-network": "^9.0.0"
       },
       "dependencies": {
         "uuid": {
@@ -5629,9 +5754,9 @@
       }
     },
     "react-input-autosize": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
-      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz",
+      "integrity": "sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==",
       "requires": {
         "prop-types": "^15.5.8"
       }
@@ -5642,11 +5767,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-json-view": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.19.1.tgz",
-      "integrity": "sha512-u5e0XDLIs9Rj43vWkKvwL8G3JzvXSl6etuS5G42a8klMohZuYFQzSN6ri+/GiBptDqlrXPTdExJVU7x9rrlXhg==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/react-json-view/-/react-json-view-1.21.1.tgz",
+      "integrity": "sha512-AonvGea4nWlsnNXCbnSdUHsetyNS8rUMhbFHS9eFaDB1oeaxgHcVsqo5LhGRMvWybfDdjVUo0xzDoMQP7jbrXw==",
       "requires": {
-        "flux": "^3.1.3",
+        "flux": "^4.0.1",
         "react-base16-styling": "^0.6.0",
         "react-lifecycles-compat": "^3.0.4",
         "react-textarea-autosize": "^6.1.0"
@@ -5680,17 +5805,17 @@
       "integrity": "sha512-oAPVOCMApTT0HkxZJy84yU1EWaaQNZnJE0DjDMy/L+LxZoJEph4RRXsT9ppPKbFSo/tCzj+cCLwiBHjZmZ2eXA=="
     },
     "react-number-format": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-4.4.3.tgz",
-      "integrity": "sha512-9PNKWfLZVR4EMK9R1LkfXRmWqezSIeMOl7YFsuCcniZZxLiNxEX7ovvxZLXN8XNm6TGP8dZ31GnV5V64oDnkuA==",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-4.4.4.tgz",
+      "integrity": "sha512-/MuF1GOs1Z0xBaQie8+TTqCxUTT8xxjc6RqIFVWcWB6FM8GNIenSh2ayzN6Y1J2WMcXUDVwMdDXjweHKVjXm/w==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "react-range": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.8.5.tgz",
-      "integrity": "sha512-xWHMyq30lSxNnMMkUBrAvxSJUfxVCyQr/k0WI6aFFljCDq8obmu8zeHj1dODRBk2dV4QCmSD3Sszbc1b1U35hQ=="
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/react-range/-/react-range-1.8.7.tgz",
+      "integrity": "sha512-M8vaKB2vCU04BWq/kae/e5xu5WWm/lfFHXWkSiFWWm00+fqNvhYAeNYmiXR82WgwQAwRmew7Wcy7HC9pZj5QcA=="
     },
     "react-render-to-json": {
       "version": "0.0.6",
@@ -5740,9 +5865,9 @@
       }
     },
     "react-select": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.1.tgz",
-      "integrity": "sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.2.0.tgz",
+      "integrity": "sha512-B/q3TnCZXEKItO0fFN/I0tWOX3WJvi/X2wtdffmwSQVRwg5BpValScTO1vdic9AxlUgmeSzib2hAZAwIUQUZGQ==",
       "requires": {
         "@babel/runtime": "^7.4.4",
         "@emotion/cache": "^10.0.9",
@@ -5750,7 +5875,7 @@
         "@emotion/css": "^10.0.9",
         "memoize-one": "^5.0.0",
         "prop-types": "^15.6.0",
-        "react-input-autosize": "^2.2.2",
+        "react-input-autosize": "^3.0.0",
         "react-transition-group": "^4.3.0"
       }
     },
@@ -5781,20 +5906,19 @@
       }
     },
     "react-toastify": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-5.5.0.tgz",
-      "integrity": "sha512-jsVme7jALIFGRyQsri/g4YTsRuaaGI70T6/ikjwZMB4mwTZaCWqj5NqxhGrRStKlJc5npXKKvKeqTiRGQl78LQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-6.2.0.tgz",
+      "integrity": "sha512-XpjFrcBhQ0/nBOL4syqgP/TywFnOyxmstYLWgSQWcj39qpp+WU4vPt3C/ayIDx7RFyxRWfzWTdR2qOcDGo7G0w==",
       "requires": {
-        "@babel/runtime": "^7.4.2",
-        "classnames": "^2.2.6",
+        "clsx": "^1.1.1",
         "prop-types": "^15.7.2",
-        "react-transition-group": "^4"
+        "react-transition-group": "^4.4.1"
       }
     },
     "react-tooltip": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.11.tgz",
-      "integrity": "sha512-exREte3mK/qbeuQpFbEL3ImdF5/TSAb+x/T7pkVfKmgVcfQLZKHSgLN+Msv7ZOHxaWNJwuCrSsCAy/iTGoPigg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.14.tgz",
+      "integrity": "sha512-hS2kAlpjyH5MXL9DaGKsdmEFCIEuMD2RZXkEJeNjmDe05dHpqj93o5JgpmczAgQFk099+JSsnHUDo7pIOuyMDQ==",
       "requires": {
         "prop-types": "^15.7.2",
         "uuid": "^7.0.3"
@@ -5866,6 +5990,14 @@
         }
       }
     },
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
     "rechoir": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
@@ -5917,6 +6049,11 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -6286,16 +6423,25 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
     "store2": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/store2/-/store2-2.12.0.tgz",
       "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw=="
     },
+    "strict-event-emitter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz",
+      "integrity": "sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw=="
+    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
       "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6337,7 +6483,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.0"
       }
@@ -6435,9 +6580,9 @@
       }
     },
     "svgpath": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.3.0.tgz",
-      "integrity": "sha512-N/4UDu3Y2ICik0daMmFW1tplw0XPs1nVIEVYkTiQfj9/JQZeEtAKaSYwheCwje1I4pQ5r22fGpoaNIvGgsyJyg=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/svgpath/-/svgpath-2.3.1.tgz",
+      "integrity": "sha512-wNz6lCoj+99GMoyU7SozTfPqiLHz6WcJYZ30Z+F4lF/gPtxWHBCpZ4DhoDI0+oZ0dObKyYsJdSPGbL2mJq/qCg=="
     },
     "svgtodatauri": {
       "version": "0.0.0",
@@ -6601,11 +6746,6 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
-    "timsort": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
-    },
     "tiny-invariant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
@@ -6640,7 +6780,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       },
@@ -6648,8 +6787,7 @@
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-          "dev": true
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         }
       }
     },
@@ -6668,9 +6806,9 @@
       "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
     },
     "ts-debounce": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-2.1.0.tgz",
-      "integrity": "sha512-jlrN8iK/Iif5pQd+pIsH8uEexj3vvUT+BwqNrJt5xgZB+ucwVfQVAUMC8Dnx0vlk7AktHxoD9ZDYYVYUtxd5wA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-2.3.0.tgz",
+      "integrity": "sha512-j63IP7/unAzovrhVHE7U+fNkvDKwIaLH11dCO9TcRbYOZw1chPL054poqq3ZloyRJ5KwJMeB8csN/vGPPpQJjw=="
     },
     "ts-dedent": {
       "version": "1.2.0",
@@ -6713,30 +6851,19 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.23",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.23.tgz",
-      "integrity": "sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA=="
+      "version": "0.7.24",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.24.tgz",
+      "integrity": "sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw=="
     },
     "uncontrollable": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.1.1.tgz",
-      "integrity": "sha512-EcPYhot3uWTS3w00R32R2+vS8Vr53tttrvMj/yA1uYRhf8hbTG2GyugGqWDY0qIskxn0uTTojVd6wPYW9ZEf8Q==",
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
+      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
       "requires": {
         "@babel/runtime": "^7.6.3",
-        "@types/react": "^16.9.11",
+        "@types/react": ">=16.9.11",
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
-      },
-      "dependencies": {
-        "@types/react": {
-          "version": "16.14.2",
-          "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
-          "integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
-          "requires": {
-            "@types/prop-types": "*",
-            "csstype": "^3.0.2"
-          }
-        }
       }
     },
     "uniq": {
@@ -6919,44 +7046,14 @@
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vis-data": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-6.6.1.tgz",
-      "integrity": "sha512-xmujDB2Dzf8T04rGFJ9OP4OA6zRVrz8R9hb0CVKryBrZRCljCga9JjSfgctA8S7wdZu7otDtUIwX4ZOgfV/57w=="
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.2.tgz",
+      "integrity": "sha512-RPSegFxEcnp3HUEJSzhS2vBdbJ2PSsrYYuhRlpHp2frO/MfRtTYbIkkLZmPkA/Sg3pPfBlR235gcoKbtdm4mbw=="
     },
     "vis-network": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-5.4.1.tgz",
-      "integrity": "sha512-hUJlFWoCmLup6IxoXCr//OO2ZCkC8jrXEkkHLG1DhBgB54Y3K33+e5q4tc436inMlGzfqqaKTIToNbOGr8Szww==",
-      "requires": {
-        "@egjs/hammerjs": "^2.0.15",
-        "component-emitter": "^1.3.0",
-        "keycharm": "^0.2.0",
-        "moment": "^2.24.0",
-        "timsort": "^0.3.0",
-        "vis-data": "^6.1.1",
-        "vis-util": "^1.1.6"
-      }
-    },
-    "vis-util": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-1.1.10.tgz",
-      "integrity": "sha512-8hGSxsFi2ogYYweClQyITzWnirWgQ8p0i9M4d3OXMuUO8vjXrf+2zHOYI9OZbtUduxAWuMEePnS9BXDtPJmJ7Q==",
-      "requires": {
-        "moment": "2.24.0",
-        "vis-uuid": "1.1.3"
-      },
-      "dependencies": {
-        "moment": {
-          "version": "2.24.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-          "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
-        }
-      }
-    },
-    "vis-uuid": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/vis-uuid/-/vis-uuid-1.1.3.tgz",
-      "integrity": "sha512-2B6XdY1bkzbUh+TugmnAaFa61KO9R5pzBzIuFIm8a9FrkbxIdSmQXV+FbfkL8QunkQV/bT0JDLQ2puqCS2+0Og=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.0.2.tgz",
+      "integrity": "sha512-0UFs81YsGcHSzZG5d3AsDQDvREF0h0/mAqzRDV+62jq0Tj5fpJzB+xvcbRuZfQIfrYN7DqNsHXvNOthAuCAlrg=="
     },
     "warning": {
       "version": "4.0.3",
@@ -7154,11 +7251,6 @@
         }
       }
     },
-    "whatwg-fetch": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.5.0.tgz",
-      "integrity": "sha512-jXkLtsR42xhXg7akoDKvKWE40eJeI+2KZqcp2h3NsOrRnDvtWX36KcKl30dy+hxECivdk2BVUHVNrPtoMBUx6A=="
-    },
     "which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7218,6 +7310,39 @@
         }
       }
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -7251,6 +7376,11 @@
         }
       }
     },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -7260,6 +7390,25 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
       "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA=="
     },
     "yocto-queue": {
       "version": "0.1.0",


### PR DESCRIPTION
This PR contains an update to the band structure component to accommodate the changes from https://github.com/materialsproject/pymatgen/pull/1968 and https://github.com/materialsproject/pymatgen/pull/2019.

More specifically:

- Path continuity for LM band structures now handled completely with `get_continuous_path`
- VBM and CBM dot fix no longer needed and removed
- Plot data index changes accommodated 