### PR TITLE
Magnetic moment visualization

### DIFF
--- a/crystal_toolkit/apps/examples/structure.py
+++ b/crystal_toolkit/apps/examples/structure.py
@@ -18,7 +18,7 @@ structure = Structure(
     Lattice.cubic(4.2),
     ["Na", "K"],
     [[0, 0, 0], [0.5, 0.5, 0.5]],
-    site_properties={"magmom": [-10, 10]},
+    site_properties={"magmom": [-2, 2]},
 )
 
 # create the Crystal Toolkit component

--- a/crystal_toolkit/apps/examples/structure_magnetic.py
+++ b/crystal_toolkit/apps/examples/structure_magnetic.py
@@ -1,0 +1,54 @@
+# standard Dash imports
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
+
+# import for this example
+from pymatgen.core.structure import Structure
+from pymatgen.core.lattice import Lattice
+from pymatgen.electronic_structure.core import Magmom
+
+# standard Crystal Toolkit import
+import crystal_toolkit.components as ctc
+
+# create Dash app as normal
+app = dash.Dash()
+
+# create the Structure object
+structure = Structure(
+    Lattice.cubic(3.0),
+    ["Ni", "Ti"],
+    [[0, 0, 0], [0.5, 0.5, 0.5]],
+    site_properties={"magmom": [[-2.0, 1.0, 0.0], [1.0, 1.0, -1.0]]},
+    # site_properties={"magmom": [3.0, -2.0]},
+)
+
+# create the Crystal Toolkit component
+structure_component = ctc.StructureMoleculeComponent(structure, id="struct")
+
+# example layout to demonstrate capabilities of component
+my_layout = html.Div(
+    [
+        html.H1("StructureMoleculeComponent Example"),
+        html.H2("Standard Layout"),
+        structure_component.layout(size="400px"),
+        html.H2("Optional Additional Layouts"),
+        html.H3("Screenshot Layout"),
+        structure_component.screenshot_layout(),
+        html.H3("Options Layout"),
+        structure_component.options_layout(),
+        html.H3("Title Layout"),
+        structure_component.title_layout(),
+        html.H3("Legend Layout"),
+        structure_component.legend_layout(),
+    ]
+)
+
+# tell crystal toolkit about your app and layout
+ctc.register_crystal_toolkit(app, layout=my_layout)
+
+# allow app to be run using "python structure.py"
+# in production, deploy behind gunicorn or similar
+# see Dash documentation for more information
+if __name__ == "__main__":
+    app.run_server(debug=True, port=8050)

--- a/crystal_toolkit/renderables/structuregraph.py
+++ b/crystal_toolkit/renderables/structuregraph.py
@@ -132,14 +132,14 @@ def get_structure_graph_scene(
             color_edges = True
 
     idx_to_wyckoff = {}
-    if group_by_symmetry:
-        sga = SpacegroupAnalyzer(self.structure)
-        struct_sym = sga.get_symmetrized_structure()
-        for equiv_idxs, wyckoff in zip(
-            struct_sym.equivalent_indices, struct_sym.wyckoff_symbols
-        ):
-            for idx in equiv_idxs:
-                idx_to_wyckoff[idx] = wyckoff
+    # if group_by_symmetry:
+    #     sga = SpacegroupAnalyzer(self.structure)
+    #     struct_sym = sga.get_symmetrized_structure()
+    #     for equiv_idxs, wyckoff in zip(
+    #         struct_sym.equivalent_indices, struct_sym.wyckoff_symbols
+    #     ):
+    #         for idx in equiv_idxs:
+    #             idx_to_wyckoff[idx] = wyckoff
 
     for (idx, jimage) in sites_to_draw:
 


### PR DESCRIPTION
- Added collection of `Arrows` to `Site` rendering to visualize noncollinear magnetic moments, in addition to collinear moments (in the direction of `saxis` indicated by `pymatgen`'s `Magmom`) 
- In addition, added a relevant example to `apps/examples/structure_magnetic.py` modeled closely after `apps/examples/structure.py`

Tagging: @mkhorton