### PR TITLE
Update structure controls

### DIFF
--- a/crystal_toolkit/apps/examples/basic_hello_structure.py
+++ b/crystal_toolkit/apps/examples/basic_hello_structure.py
@@ -4,6 +4,7 @@ from dash import html
 from dash import dcc
 import crystal_toolkit.components as ctc
 
+# app = dash.Dash(external_stylesheets=['https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css'])
 app = dash.Dash()
 
 # create our crystal structure using pymatgen

--- a/crystal_toolkit/apps/examples/basic_hello_structure.py
+++ b/crystal_toolkit/apps/examples/basic_hello_structure.py
@@ -13,7 +13,7 @@ from pymatgen.core.lattice import Lattice
 structure = Structure(Lattice.cubic(4.2), ["Na", "K"], [[0, 0, 0], [0.5, 0.5, 0.5]])
 
 # create the Crystal Toolkit component
-structure_component = ctc.StructureMoleculeComponent(structure, show_controls=False)
+structure_component = ctc.StructureMoleculeComponent(structure, show_controls=True)
 
 # add the component's layout to our app's layout
 my_layout = html.Div([structure_component.layout()])

--- a/crystal_toolkit/apps/examples/basic_hello_structure.py
+++ b/crystal_toolkit/apps/examples/basic_hello_structure.py
@@ -13,7 +13,7 @@ from pymatgen.core.lattice import Lattice
 structure = Structure(Lattice.cubic(4.2), ["Na", "K"], [[0, 0, 0], [0.5, 0.5, 0.5]])
 
 # create the Crystal Toolkit component
-structure_component = ctc.StructureMoleculeComponent(structure)
+structure_component = ctc.StructureMoleculeComponent(structure, show_controls=False)
 
 # add the component's layout to our app's layout
 my_layout = html.Div([structure_component.layout()])

--- a/crystal_toolkit/apps/examples/structure.py
+++ b/crystal_toolkit/apps/examples/structure.py
@@ -30,17 +30,8 @@ my_layout = html.Div(
         html.H1("StructureMoleculeComponent Example"),
         html.H2("Standard Layout"),
         structure_component.layout(size="400px"),
-        html.H2("Optional Additional Layouts"),
-        html.H3("Screenshot Layout"),
-        structure_component.screenshot_layout(),
-        html.H3("Options Layout"),
-        structure_component.options_layout(),
-        html.H3("Title Layout"),
+        html.H2("Optional Title Layout"),
         structure_component.title_layout(),
-        html.H3("Legend Layout"),
-        structure_component.legend_layout(),
-        html.H3("Download Layout"),
-        structure_component.download_layout(),
     ]
 )
 

--- a/crystal_toolkit/apps/examples/tests/test_structure.py
+++ b/crystal_toolkit/apps/examples/tests/test_structure.py
@@ -10,6 +10,10 @@ def test_structure(dash_duo):
     time.sleep(5)
     dash_duo.percy_snapshot("example_structure_on_load")
 
+    # click the settings button (second button in the button-bar) to show the settings panel
+    # and test the settings options.
+    dash_duo.find_elements(".mpc-button-bar .button")[1].click()
+
     # test changing radius
     el = dash_duo.select_dcc_dropdown("#CTmy_structure_radius_strategy", index=0)
     time.sleep(1)

--- a/crystal_toolkit/components/pourbaix.py
+++ b/crystal_toolkit/components/pourbaix.py
@@ -563,14 +563,12 @@ class PourbaixDiagramComponent(MPComponent):
             style={"display": "inline-block"},
         )
 
-        graph = ctl.Box(
-            ctl.Loading(
-                dcc.Graph(
-                    figure=go.Figure(layout=PourbaixDiagramComponent.empty_plot_style),
-                    id=self.id("graph"),
-                    responsive=True,
-                    config={"displayModeBar": False, "displaylogo": False},
-                )
+        graph = html.Div(
+            dcc.Graph(
+                figure=go.Figure(layout=PourbaixDiagramComponent.empty_plot_style),
+                id=self.id("graph"),
+                responsive=True,
+                config={"displayModeBar": False, "displaylogo": False},
             ),
             style={"min-height": "500px"},
         )

--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -148,7 +148,7 @@ class StructureMoleculeComponent(MPComponent):
         self.show_settings = show_settings
         self.show_controls = show_controls
         self.show_position_button = show_position_button
-        
+
         self.initial_scene_settings = self.default_scene_settings.copy()
         if scene_settings:
             self.initial_scene_settings.update(scene_settings)
@@ -434,8 +434,6 @@ class StructureMoleculeComponent(MPComponent):
             ],
         )
         def download_image(image_data_timestamp, image_data, data):
-            print('image data')
-            print(image_data_timestamp)
             if not image_data_timestamp:
                 raise PreventUpdate
 
@@ -468,8 +466,6 @@ class StructureMoleculeComponent(MPComponent):
             ],
         )
         def download_structure(file_timestamp, download_option, data):
-            print('file data')
-            print(file_timestamp)
             if not file_timestamp:
                 raise PreventUpdate
 
@@ -604,20 +600,21 @@ class StructureMoleculeComponent(MPComponent):
         )
 
         legend_elements = [
-            Button(
+            html.Span(
                 html.Span(
                     name, className="icon", style={"color": get_font_color(color)}
                 ),
-                kind="static",
+                className="button is-static is-rounded",
                 style={"backgroundColor": color},
             )
             for color, name in legend_colors.items()
         ]
 
-        return Field(
-            [Control(el, style={"marginRight": "0.2rem"}) for el in legend_elements],
+        return html.Div(
+            legend_elements,
             id=self.id("legend"),
-            grouped=True,
+            style={"display": "flex"},
+            className="buttons"
         )
 
     def _make_title(self, legend):

--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -422,7 +422,7 @@ class StructureMoleculeComponent(MPComponent):
         # )
 
         @app.callback(
-            Output(self.id("download"), "data"),
+            Output(self.id("download-image"), "data"),
             Input(self.id("scene"), "imageDataTimestamp"),
             [
                 State(self.id("scene"), "imageData"),
@@ -430,6 +430,8 @@ class StructureMoleculeComponent(MPComponent):
             ],
         )
         def download_image(image_data_timestamp, image_data, data):
+            print('image data')
+            print(image_data_timestamp)
             if not image_data_timestamp:
                 raise PreventUpdate
 
@@ -462,7 +464,8 @@ class StructureMoleculeComponent(MPComponent):
             ],
         )
         def download_structure(file_timestamp, download_option, data):
-
+            print('file data')
+            print(file_timestamp)
             if not file_timestamp:
                 raise PreventUpdate
 
@@ -867,8 +870,11 @@ class StructureMoleculeComponent(MPComponent):
                     sceneSize="100%",
                     fileOptions=list(self.download_options["Structure"].keys()),
                     hideControls=False if self.show_controls else True,
+                    showPositionButton=True if self.show_position_button else False,
                     **self.scene_kwargs,
                 ),
+                dcc.Download(id=self.id("download-image")),
+                dcc.Download(id=self.id("download-structure"))
             ],
             style={
                 "width": "100%",

--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -51,6 +51,7 @@ DEFAULTS = {
     "show_compass": True,
     "unit_cell_choice": "input",
     "show_legend": True,
+    "show_settings": True,
     "show_controls": True,
     "show_position_button": False
 }
@@ -113,6 +114,7 @@ class StructureMoleculeComponent(MPComponent):
         scene_settings: Optional[Dict] = None,
         group_by_site_property: Optional[str] = None,
         show_legend: bool = DEFAULTS["show_legend"],
+        show_settings: bool = DEFAULTS["show_settings"],
         show_controls: bool = DEFAULTS["show_controls"],
         show_position_button: bool = DEFAULTS["show_position_button"],
         **kwargs,
@@ -143,8 +145,10 @@ class StructureMoleculeComponent(MPComponent):
 
         super().__init__(id=id, default_data=struct_or_mol, **kwargs)
         self.show_legend = show_legend
+        self.show_settings = show_settings
         self.show_controls = show_controls
         self.show_position_button = show_position_button
+        
         self.initial_scene_settings = self.default_scene_settings.copy()
         if scene_settings:
             self.initial_scene_settings.update(scene_settings)
@@ -719,7 +723,7 @@ class StructureMoleculeComponent(MPComponent):
             style={"display": "none"},
         )
 
-        if self.show_controls:
+        if self.show_settings:
             options_layout = Field(
                 [
                     #  TODO: hide if molecule

--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -876,13 +876,7 @@ class StructureMoleculeComponent(MPComponent):
                 ),
                 dcc.Download(id=self.id("download-image")),
                 dcc.Download(id=self.id("download-structure"))
-            ],
-            style={
-                "width": "100%",
-                "height": "100%",
-                "overflow": "hidden",
-                "margin": "0 auto",
-            },
+            ]
         )
 
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ gunicorn = { version = "*", optional = true }
 redis = { version = "*", optional = true }
 Flask-Caching = { version = "*", optional = true }
 gevent = { version = "*", optional = true }
-dash-mp-components = {version = "^0.3.44", optional = true}
+dash-mp-components = "^0.3.82"
 robocrys = { version = "*", optional = true }
 habanero = { version = "*", optional = true }
 dscribe = { version = "*", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ gunicorn = { version = "*", optional = true }
 redis = { version = "*", optional = true }
 Flask-Caching = { version = "*", optional = true }
 gevent = { version = "*", optional = true }
-dash-mp-components = "^0.3.82"
+dash-mp-components = "^0.3.83"
 robocrys = { version = "*", optional = true }
 habanero = { version = "*", optional = true }
 dscribe = { version = "*", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Matthew Horton <mkhorton@lbl.gov>"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = ">=3.8, <3.11"
 pymatgen = "^2022.0.16"
 pydantic = "*"
 plotly = "^5.3.1"
@@ -34,6 +34,7 @@ dash-extensions = { version = "*", optional = true }
 sentry-sdk = { version = "*", optional = true }
 dash-vtk = { version = "^0.0.6", optional= true }
 kaleido = { version = "^0.2.1", optional = true }
+numba = ">=0.53"
 
 [tool.poetry.extras]
 server = [


### PR DESCRIPTION
- Rendering for `StructureMoleculeComponent` controls are now handled by the `CrystalToolkitScene` react component
- Image downloads are now handled by a single callback
- Export file options are now passed to `CrystalToolkitScene` via the `fileOptions` prop. These are rendered in a dropdown that is opened via the file export button (created by the react component).
- Selected file options are emitted by the `fileType` prop on  `CrystalToolkitScene`. This is now being used for the file export callback.
- The settings panel is now passed into  `CrystalToolkitScene` via the `children` prop. The first child will always be considered the settings panel. Showing/hiding the settings panel is now handled by react.
- The legend is now also passed into  `CrystalToolkitScene` via the `children` prop. The second child will always be considered the legend.
- There is a new optional control that will return the structure to its original position.
- There are four new options on the `StructureMoleculeComponent` for controlling all the above features:
  - `show_legend`
  - `show_settings`
  - `show_controls`
  - `show_position_button`
- The box and loading components have been removed from the pourbaix diagram so that these can be controlled more easily from outside the component.

A dependency issue with `numba` and `numpy` has also been resolved. For the time being, crystaltoolkit needs to pin to numba>=0.53 and match its python requirement to numba's (< 3.11).