### PR TITLE
Add a lattice parameter to Scene

### DIFF
--- a/crystal_toolkit/core/scene.py
+++ b/crystal_toolkit/core/scene.py
@@ -45,6 +45,7 @@ class Scene:
     contents: list = field(default_factory=list)
     origin: List[float] = field(default=(0, 0, 0))
     visible: bool = True
+    lattice: Optional[List[List[float]]] = None
     _meta: Dict = None
 
     def __add__(self, other):
@@ -61,6 +62,7 @@ class Scene:
             contents=self.contents + other.contents,
             origin=self.origin,
             visible=self.visible,
+            lattice=self.lattice,
             _meta={self.name: self._meta, other.name: other._meta},
         )
 
@@ -91,6 +93,7 @@ class Scene:
             name=self.name,
             contents=self.merge_primitives(self.contents),
             origin=self.origin,
+            lattice=self.lattice,
         )
 
         def remove_defaults(scene_dict):

--- a/crystal_toolkit/core/tests/test_legend.py
+++ b/crystal_toolkit/core/tests/test_legend.py
@@ -171,3 +171,10 @@ class TestLegend:
         legend_from_dict = Legend.from_dict(legend_dict)
 
         assert legend.get_legend() == legend_from_dict.get_legend()
+
+    def test_get_tiling(self):
+        scene = self.struct.get_scene()
+        assert hasattr(scene, 'lattice')
+        assert scene.lattice == [[5.0, 0, 0],
+                                 [0, 5.0, 0],
+                                 [0, 0, 5.0]]

--- a/crystal_toolkit/renderables/structure.py
+++ b/crystal_toolkit/renderables/structure.py
@@ -101,7 +101,7 @@ def get_structure_scene(
 
     primitives["unit_cell"].append(self.lattice.get_scene())
 
-    lattice_vectors = [list(array) for array in self.lattice.matrix]
+    lattice_vectors = self.lattice.matrix.tolist()
 
     return Scene(
         name="Structure",

--- a/crystal_toolkit/renderables/structure.py
+++ b/crystal_toolkit/renderables/structure.py
@@ -69,7 +69,7 @@ def get_structure_scene(
     Args:
         self:  Structure object
         origin: fractional coordinate of the origin
-        legend: Legend for the sites
+        legend: Legend for the sites\
         draw_image_atoms: If true draw image atoms that are just outside the
         periodic boundary
 
@@ -95,16 +95,18 @@ def get_structure_scene(
                 site.lattice,
                 properties=site.properties,
             )
-
         site_scene = site.get_scene(legend=legend,)
         for scene in site_scene.contents:
             primitives[scene.name] += scene.contents
 
     primitives["unit_cell"].append(self.lattice.get_scene())
 
+    lattice_vectors = [list(array) for array in self.lattice.matrix]
+
     return Scene(
         name="Structure",
         origin=origin,
+        lattice=lattice_vectors,
         contents=[
             Scene(name=k, contents=v, origin=origin) for k, v in primitives.items()
         ],

--- a/crystal_toolkit/renderables/structure.py
+++ b/crystal_toolkit/renderables/structure.py
@@ -69,7 +69,7 @@ def get_structure_scene(
     Args:
         self:  Structure object
         origin: fractional coordinate of the origin
-        legend: Legend for the sites\
+        legend: Legend for the sites
         draw_image_atoms: If true draw image atoms that are just outside the
         periodic boundary
 


### PR DESCRIPTION
This small PR adds a lattice attribute to the Scene object and has the Structure Scene automatically add it from its own lattice vectors.

Related to work to add dynamic tiling to mp-react-components, as seen in [this PR](https://github.com/materialsproject/mp-react-components/pull/561).