### PR TITLE
Horizontal dos and some bug fix

### DIFF
--- a/crystal_toolkit/components/diffraction_tem.py
+++ b/crystal_toolkit/components/diffraction_tem.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
 from time import time
+from warnings import warn
 
 import numpy as np
 import plotly.graph_objs as go
-import py4DSTEM
+
+try:
+    import py4DSTEM
+except ImportError:
+    warn("The TEMDiffractionComponent requires the py4DSTEM package.")
+    py4DSTEM = None
 from dash import dcc, html
 from dash.dependencies import Input, Output
 
@@ -22,6 +28,14 @@ class TEMDiffractionComponent(MPComponent):
         self.calculator = TEMDiffractionCalculator()
 
     def layout(self) -> Columns:
+        if not py4DSTEM:
+            return Columns(
+                [
+                    Column(
+                        "This feature will not work unless py4DSTEM is installed on the server."
+                    )
+                ]
+            )
 
         voltage = self.get_numerical_input(
             kwarg_label="voltage",

--- a/crystal_toolkit/core/mpcomponent.py
+++ b/crystal_toolkit/core/mpcomponent.py
@@ -87,7 +87,8 @@ class MPComponent(ABC):
             cache: a flask_caching Cache instance
         """
         if SETTINGS.DEBUG_MODE:
-            cache = null_cache
+            MPComponent.cache = null_cache
+            MPComponent.cache.init_app(MPComponent.app.server)
         elif cache:
             MPComponent.cache = cache
         else:


### PR DESCRIPTION
This PR contains an upgrade to the BandstructureAndDosComponent: 
* allowing to plot the DOS horizontally, to take advantage of all the space in case the BS is missing
* options to control the portion of the figure allocated to the BS and DOS
The default options did not change.

and few bug fix:
* the API of the `SOAP` descriptor in the dscribe library has changed some time ago, changing the `average` argument type from a bool to a str. This resulted in a broken LocalEnvironmentPanel for SOAP (not working even on the MP website). Changed the `average` option and updated the code accordingly.
* in DEBUG_MODE the null cache was not properly taken into account. 
* the new `diffraction_tem` module imports directly py4DSTEM, which is optional. Added a check to prevent an ImportError.