### PR TITLE
fix chemenv view

### DIFF
--- a/crystal_toolkit/components/localenv.py
+++ b/crystal_toolkit/components/localenv.py
@@ -39,7 +39,7 @@ from crystal_toolkit.helpers.layouts import (
     Label,
     Loading,
     cite_me,
-    get_data_list,
+    get_table,
     get_tooltip,
 )
 
@@ -786,10 +786,10 @@ class LocalEnvironmentPanel(PanelComponent):
             unknown_sites = []
 
             for index, wyckoff in zip(inequivalent_indices, wyckoffs):
-                datalist = {
-                    "Site": unicodeify_species(struct[index].species_string),
-                    "Wyckoff Label": wyckoff,
-                }
+                datalist = [
+                    ["Site", unicodeify_species(struct[index].species_string)],
+                    ["Wyckoff Label", wyckoff],
+                ]
 
                 if not lse.neighbors_sets[index]:
                     unknown_sites.append(f"{struct[index].species_string} ({wyckoff})")
@@ -822,11 +822,11 @@ class LocalEnvironmentPanel(PanelComponent):
                 if co.alternative_names:
                     name += f" (also known as {', '.join(co.alternative_names)})"
 
-                datalist.update(
-                    {
-                        "Environment": name,
-                        "IUPAC Symbol": co.IUPAC_symbol_str,
-                        get_tooltip(
+                datalist.extend(
+                    [
+                        ["Environment", name],
+                        ["IUPAC Symbol", co.IUPAC_symbol_str],
+                        [get_tooltip(
                             "CSM",
                             "The continuous symmetry measure (CSM) describes the similarity to an "
                             "ideal coordination environment. It can be understood as a 'distance' to "
@@ -834,12 +834,12 @@ class LocalEnvironmentPanel(PanelComponent):
                             "coordination environment that is exactly identical to the ideal one. A "
                             "CSM larger than 5.0 already indicates a relatively strong distortion of "
                             "the investigated coordination environment.",
-                        ): f"{env[0]['csm']:.2f}",
-                        "Interactive View": view,
-                    }
+                        ), f"{env[0]['csm']:.2f}"],
+                        ["Interactive View", view],
+                    ]
                 )
 
-                envs.append(get_data_list(datalist))
+                envs.append(get_table(rows=datalist))
 
             # TODO: switch to tiles?
             envs_grouped = [envs[i : i + 2] for i in range(0, len(envs), 2)]

--- a/crystal_toolkit/components/localenv.py
+++ b/crystal_toolkit/components/localenv.py
@@ -826,15 +826,18 @@ class LocalEnvironmentPanel(PanelComponent):
                     [
                         ["Environment", name],
                         ["IUPAC Symbol", co.IUPAC_symbol_str],
-                        [get_tooltip(
-                            "CSM",
-                            "The continuous symmetry measure (CSM) describes the similarity to an "
-                            "ideal coordination environment. It can be understood as a 'distance' to "
-                            "a shape and ranges from 0 to 100 in which 0 corresponds to a "
-                            "coordination environment that is exactly identical to the ideal one. A "
-                            "CSM larger than 5.0 already indicates a relatively strong distortion of "
-                            "the investigated coordination environment.",
-                        ), f"{env[0]['csm']:.2f}"],
+                        [
+                            get_tooltip(
+                                "CSM",
+                                "The continuous symmetry measure (CSM) describes the similarity to an "
+                                "ideal coordination environment. It can be understood as a 'distance' to "
+                                "a shape and ranges from 0 to 100 in which 0 corresponds to a "
+                                "coordination environment that is exactly identical to the ideal one. A "
+                                "CSM larger than 5.0 already indicates a relatively strong distortion of "
+                                "the investigated coordination environment.",
+                            ),
+                            f"{env[0]['csm']:.2f}",
+                        ],
                         ["Interactive View", view],
                     ]
                 )

--- a/crystal_toolkit/renderables/moleculegraph.py
+++ b/crystal_toolkit/renderables/moleculegraph.py
@@ -36,16 +36,16 @@ def get_molecule_graph_scene(
         A Molecule Graph scene
     """
 
-    vis_mol_graph = MoleculeGraph.with_local_env_strategy(self.molecule, OpenBabelNN())
+    if visualize_bond_orders:
+        vis_mol_graph = MoleculeGraph.with_local_env_strategy(self.molecule, OpenBabelNN())
+    else:
+        vis_mol_graph = self
     legend = legend or Legend(self.molecule)
 
     primitives: dict[str, list] = defaultdict(list)
 
     for idx, site in enumerate(self.molecule):
-        if visualize_bond_orders:
-            connected_sites = vis_mol_graph.get_connected_sites(idx)
-        else:
-            connected_sites = self.get_connected_sites(idx)
+        connected_sites = vis_mol_graph.get_connected_sites(idx)
 
         site_scene = site.get_scene(
             site_idx=idx,

--- a/crystal_toolkit/renderables/moleculegraph.py
+++ b/crystal_toolkit/renderables/moleculegraph.py
@@ -37,7 +37,9 @@ def get_molecule_graph_scene(
     """
 
     if visualize_bond_orders:
-        vis_mol_graph = MoleculeGraph.with_local_env_strategy(self.molecule, OpenBabelNN())
+        vis_mol_graph = MoleculeGraph.with_local_env_strategy(
+            self.molecule, OpenBabelNN()
+        )
     else:
         vis_mol_graph = self
     legend = legend or Legend(self.molecule)


### PR DESCRIPTION
Due to a change in the `get_data_list` function the visualization of the chemenv local environment was broken. This PR fixes the problem by replacing with the `get_table` function instead.
In addition a hard dependency for openbabel was introduced in the code https://github.com/materialsproject/crystaltoolkit/commit/1bfaddfb42e07c08fb15451dbef0a9c638224bde. However, this is not always needed and since openbabel may be a pain to install in some cases now the Openbabel object is only instantiated if really needed.