### PR TITLE
Add missing core deps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,18 +12,18 @@ exclude: ^(docs/.+|.*lock.*|jupyterlab-extension/.+|.*\.(svg|js|css))$
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.255
+    rev: v0.0.260
     hooks:
       - id: ruff
         args: [--fix, --ignore, D]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black-jupyter
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.991
+    rev: v1.1.1
     hooks:
       - id: mypy
 
@@ -38,14 +38,14 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.2.4
     hooks:
       - id: codespell
         stages: [commit, commit-msg]
         args: [--ignore-words-list, "nd,te"]
 
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.1
+    rev: 1.6.4
     hooks:
       - id: nbqa-ruff
 

--- a/crystal_toolkit/components/__init__.py
+++ b/crystal_toolkit/components/__init__.py
@@ -21,7 +21,6 @@ from crystal_toolkit.components.phonon import (
     PhononBandstructureAndDosPanelComponent,
 )
 from crystal_toolkit.components.pourbaix import PourbaixDiagramComponent
-from crystal_toolkit.components.robocrys import RobocrysComponent
 from crystal_toolkit.components.search import SearchComponent
 from crystal_toolkit.components.structure import StructureMoleculeComponent
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ select = [
     "YTT", # flake8-2020
 ]
 ignore = [
+    "B028",   # No explicit stacklevel keyword argument found
     "B904",   # Within an except clause, raise exceptions with raise ... from err
     "C408",   # Unnecessary dict call - rewrite as a literal
     "D100",   # Missing docstring in public module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,27 +11,21 @@ requires-python = ">=3.8"
 authors = [{ name = "Matt Horton", email = "mkhorton@lbl.gov" }]
 
 dependencies = [
-    "pymatgen",
-    "webcolors",
     "crystaltoolkit-extension",
-    "shapely",
-    "scikit-learn",
+    "dash-daq",
+    "dash-mp-components",
+    "dash",
+    "flask-caching",
+    "pymatgen",
     "scikit-image",
+    "scikit-learn",
+    "shapely",
+    "webcolors",
 ]
 
 [project.optional-dependencies]
-server = [
-    "dash<2.6",
-    "dash-daq",
-    "gunicorn[gevent]",
-    "redis",
-    "Flask-Caching",
-    "dash-mp-components",
-    "robocrys",
-    "habanero",
-    "hiphive",
-    "dash-extensions<=0.1.5",
-]
+server = ["dash-extensions", "gunicorn[gevent]", "habanero", "hiphive", "redis"]
+robocrys = ["robocrys"]
 temdiff = ["py4DSTEM>=0.13.11"]
 fermi = ["ifermi", "pyfftw"]
 vtk = ["dash-vtk"]
@@ -39,12 +33,12 @@ localenv = ["dscribe"]
 figures = ["kaleido"]
 dev = [
     "black",
-    "pre-commit",
-    "dash[testing]<2.6",
-    "sphinx_rtd_theme",
-    "recommonmark",
+    "dash[testing]",
     "dephell",
-    "jinja2<3.1",
+    "jinja2",
+    "pre-commit",
+    "recommonmark",
+    "sphinx_rtd_theme",
 ]
 
 [project.urls]


### PR DESCRIPTION
@mkhorton I just ran a CTK app in a clean environment and noticed that many core dependencies are not listed in `pyproject.toml` and hence not auto-installed alongside CTK. In particular, I got `ImportErrors` for

- `dash`
- `dash-daq`
- `dash-mp-components`
- `flask-caching`

This PR adds these packages to `pyproject.toml` `dependencies`. It also removes the `RobocrysComponent` import from `crystal_toolkit/components/__init__.py` so as not to require a `robocrys` installation for people not using the component.

There were a bunch of uncommented upward pins in `pyproject.toml`. Assuming whatever required the pins in the past is now outdated, I removed all of them.