### PR TITLE
Prevent clashing MPComponent IDs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: black-jupyter
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.2.0
     hooks:
       - id: mypy
 

--- a/crystal_toolkit/core/mpcomponent.py
+++ b/crystal_toolkit/core/mpcomponent.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from abc import ABC
 from ast import literal_eval
 from base64 import b64encode
@@ -200,6 +201,15 @@ class MPComponent(ABC):
             id = f"{CT_NAMESPACE}{type(self).__name__}"
         elif not id.startswith(CT_NAMESPACE):
             id = f"{CT_NAMESPACE}{id}"
+        while id in MPComponent._all_id_basenames:
+            # check if id ends with counter
+            if not re.search(r"-\d+$", id):
+                id += "-1"
+            else:
+                # increment counter at end of id until unique
+                print(f"{id=}")
+                next_ids = int(re.search(r"-(\d+)$", id).group(1)) + 1
+                id = re.sub(r"-\d+$", f"-{next_ids}", id)
         MPComponent._all_id_basenames.add(id)
 
         self._id = id

--- a/crystal_toolkit/core/mpcomponent.py
+++ b/crystal_toolkit/core/mpcomponent.py
@@ -207,7 +207,6 @@ class MPComponent(ABC):
                 id += "-1"
             else:
                 # increment counter at end of id until unique
-                print(f"{id=}")
                 next_ids = int(re.search(r"-(\d+)$", id).group(1)) + 1
                 id = re.sub(r"-\d+$", f"-{next_ids}", id)
         MPComponent._all_id_basenames.add(id)


### PR DESCRIPTION
This PR fixes the error

```py
DuplicateIdError: Duplicate component id found in the initial layout: `CTstructure`
```

by appending a counter to every duplicate ID and incrementing it until the ID is unique. Not sure if this is an elegant solution. The current code explicit warns against this:

https://github.com/materialsproject/crystaltoolkit/blob/a291123709315760ce467aae29435fb8fd6da615/crystal_toolkit/core/mpcomponent.py#L194-L203

But based on the frequency with which I encounter this error in my personal use (and apparently even MP production), maybe worth a try? Perhaps @mkhorton who [wrote that comment 2 years ago](https://github.com/materialsproject/crystaltoolkit/commit/89697668242ea128a932a41a5c2cecb3a69d494c#diff-39770be153d8668c3a88c8de206238456f05cadf56a0ec5d00b48d96bbfc4ebfR214) remembers what other unexpected behavior changing the IDs might have?


<details><summary>Minimal code to trigger the error</summary>

```py
from dash import Dash, html
from pymatgen.core import Lattice, Structure

import crystal_toolkit.components as ctc
from crystal_toolkit.settings import SETTINGS

structure = Structure(
    lattice=Lattice.cubic(5),
    species=("Fe", "O"),
    coords=((0, 0, 0), (0.5, 0.5, 0.5)),
)
app = Dash()

struct_comp = ctc.StructureMoleculeComponent(id="structure", struct_or_mol=structure)
struct_comp = ctc.StructureMoleculeComponent(id="structure", struct_or_mol=structure)

app.layout = html.Div([struct_comp.layout()])

ctc.register_crystal_toolkit(app=app, layout=app.layout)


app.run(port=8000)
```

The double call to `StructureMoleculeComponent` with identical `id` seems contrived/non-sensical but is what happens naturally in contexts like a dev server where code changes trigger a hot-reload.
</details> 