### PR TITLE
Drop `dash-daq`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
   autoupdate_schedule: quarterly
-  skip: [mypy]
 
 default_stages: [commit]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ exclude: ^(docs/.+|.*lock.*|jupyterlab-extension/.+|.*\.(svg|js|css))$
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.261
+    rev: v0.0.263
     hooks:
       - id: ruff
         args: [--fix, --ignore, D]
@@ -22,10 +22,10 @@ repos:
     hooks:
       - id: black-jupyter
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
-    hooks:
-      - id: mypy
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.2.0
+  #   hooks:
+  #     - id: mypy
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/crystal_toolkit/components/transformations/core.py
+++ b/crystal_toolkit/components/transformations/core.py
@@ -4,7 +4,7 @@ import traceback
 import warnings
 
 import dash
-import dash_daq as daq
+import dash_mp_components as mpc
 from dash import dcc, html
 from dash.dependencies import Component, Input, Output, State
 from dash.exceptions import PreventUpdate
@@ -49,7 +49,7 @@ class TransformationComponent(MPComponent):
 
     @property
     def _sub_layouts(self) -> dict[str, Component]:
-        enable = daq.BooleanSwitch(
+        enable = mpc.Switch(
             id=self.id("enable_transformation"),
             style={"display": "inline-block", "vertical-align": "middle"},
         )
@@ -63,8 +63,8 @@ class TransformationComponent(MPComponent):
         preview = dcc.Loading(id=self.id("preview"))
 
         if self.is_one_to_many:
-            ranked_list = daq.NumericInput(
-                value=1, min=1, max=10, id=self.id("ranked_list")
+            ranked_list = dcc.Input(
+                type="number", value=1, min=1, max=10, id=self.id("ranked_list")
             )
         else:
             # if not 1-to-many, we don't need the control, we keep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [{ name = "Matt Horton", email = "mkhorton@lbl.gov" }]
 
 dependencies = [
     "crystaltoolkit-extension",
-    "dash-daq",
     "dash-mp-components",
     "dash",
     "flask-caching",


### PR DESCRIPTION
As suggested by @mkhorton in https://github.com/materialsproject/crystaltoolkit/pull/325#issuecomment-1528181920, remove dependence on `dash-daq`.

Superseded by `dash_mp_components` and `dash.dcc`.

@tschaume What's the command for updating the `requirements/macos-latest_py3.8_extras.txt` etc. files?