### PR TITLE
Add `hook_up_fig_with_struct_viewer()` kwarg `highlight_selected`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ select = [
     "D",   # pydocstyle
     "E",   # pycodestyle error
     "F",   # pyflakes
+    "FLY", # flynt
     "I",   # isort
     "ICN", # flake8-import-conventions
     "ISC", # flake8-implicit-str-concat


### PR DESCRIPTION
A function that takes the clicked or last-hovered point and returns a dict of kwargs to be passed to `go.Figure.add_annotation()` to highlight said point. Set to `False` to disable highlighting.
Defaults to

```py
lambda point: dict(
  x=point["x"], y=point["y"], xref="x", yref="y", text=f"<b>{point['hovertext']}</b>"
)
```

Looks like this:

<img width="667" alt="Screenshot 2023-05-14 at 17 03 49" src="https://github.com/materialsproject/crystaltoolkit/assets/30958850/60f5789c-0e7e-4427-8dc7-bf90bd9b79ed">
