### PR TITLE
Fix `StructureMoleculeComponent` legend if same element has multiple oxi states

### DIFF
--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -1007,8 +1007,8 @@ class StructureMoleculeComponent(MPComponent):
             f"Invalid input type {graph}, expected one of Structure, Molecule, StructureGraph or MoleculeGraph"
         )
 
-    @staticmethod
     def get_scene_and_legend(
+        self,
         graph: StructureGraph | MoleculeGraph | None,
         color_scheme: str = DEFAULTS["color_scheme"],  # type: ignore[assignment]
         color_scale: tuple[float, float] = None,
@@ -1056,6 +1056,7 @@ class StructureMoleculeComponent(MPComponent):
             radius_scheme=radius_strategy,
             cmap_range=color_scale,
         )
+        self._legend = legend
 
         if isinstance(graph, StructureGraph):
             scene = graph.get_scene(

--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -16,7 +16,7 @@ from dash_mp_components import CrystalToolkitScene
 from emmet.core.settings import EmmetSettings
 from pymatgen.analysis.graphs import MoleculeGraph, StructureGraph
 from pymatgen.analysis.local_env import NearNeighbors
-from pymatgen.core import Composition, Molecule, Structure
+from pymatgen.core import Composition, Molecule, Species, Structure
 from pymatgen.core.periodic_table import DummySpecie
 from pymatgen.io.vasp.sets import MPRelaxSet
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
@@ -572,20 +572,15 @@ class StructureMoleculeComponent(MPComponent):
             # ensures contrasting font color for background color
             c = tuple(int(hex_code[1:][i : i + 2], 16) for i in (0, 2, 4))
             return (
-                "#000000"
+                "black"
                 if 1 - (c[0] * 0.299 + c[1] * 0.587 + c[2] * 0.114) / 255 < 0.5
-                else "#ffffff"
+                else "white"
             )
 
-        try:
-            formula = Composition.from_dict(legend["composition"]).reduced_formula
-        except Exception:
-            # TODO: fix legend for DummySpecies compositions
-            formula = "Unknown"
-
-        legend_colors = dict(
-            sorted(legend["colors"].items(), key=lambda x: formula.find(x[1]))
-        )
+        legend_colors = {
+            k: self._legend.get_color(Species(k))
+            for k, v in legend["composition"].items()
+        }
 
         legend_elements = [
             html.Span(
@@ -595,7 +590,7 @@ class StructureMoleculeComponent(MPComponent):
                 className="button is-static is-rounded",
                 style={"backgroundColor": color},
             )
-            for color, name in legend_colors.items()
+            for name, color in legend_colors.items()
         ]
 
         return html.Div(

--- a/crystal_toolkit/core/legend.py
+++ b/crystal_toolkit/core/legend.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from itertools import chain
 from typing import Any, cast
 
-import numpy as np
 from matplotlib.cm import get_cmap
 from monty.json import MSONable
 from monty.serialization import loadfn
@@ -105,13 +104,12 @@ class Legend(MSONable):
         # maximum values for color scheme, will default to be symmetric
         # about zero
         if color_scheme in site_prop_types.get("scalar", []) and not cmap_range:
-            props = np.array(
-                [
-                    p
-                    for p in site_collection.site_properties[color_scheme]
-                    if p is not None
-                ]
-            )
+            props = [
+                prop
+                for prop in site_collection.site_properties[color_scheme]
+                if prop is not None
+            ]
+
             prop_max = max(abs(min(props)), props)
             prop_min = -prop_max
             cmap_range = (prop_min, prop_max)
@@ -223,7 +221,7 @@ class Legend(MSONable):
         palette = Set1_9.colors
 
         for site_prop_name in site_prop_types.get("categorical", []):
-            props = np.array(site_collection.site_properties[site_prop_name])
+            props = site_collection.site_properties[site_prop_name]
             props[props is None] = "None"
 
             label_enc = LabelEncoder()


### PR DESCRIPTION
Closes #338.

This is a WIP to start gathering feedback. As suggested by @yang-ruoxi, this first step splits every oxi state into its own legend label without affecting the site colors. I.e. different oxi states still have the same color in the structure.

Suggestion: Make negative oxi states slightly darker, positive ones slightly brighter and combine different oxi states for the same element into 1 wider label.

This PR requires upstream changes in pymatgen: https://github.com/materialsproject/pymatgen/pull/2998 i.e. we can't put this into prod until pymatgen cuts a new release.

@mkhorton If you have time, is there any problem with making `StructureMoleculeComponent.get_scene_and_legend()` non-static? See e418cae.

Here's what this PR looks like for the problematic structure reported by @ardunn.

![Screenshot 2023-05-17 at 18 03 24](https://github.com/materialsproject/crystaltoolkit/assets/30958850/da2aa027-529b-4ade-8bf7-0678fde7c1d1)
