### PR TITLE
Fix TypeError in Legend below Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ exclude: ^(docs/.+|.*lock.*|jupyterlab-extension/.+|.*\.(svg|js|css))$
 
 repos:
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.269
+    rev: v0.0.270
     hooks:
       - id: ruff
         args: [--fix, --ignore, D]

--- a/crystal_toolkit/apps/examples/matbench_dielectric_datatable_xrd.py
+++ b/crystal_toolkit/apps/examples/matbench_dielectric_datatable_xrd.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import dash
 import plotly.io as pio
 from dash import dash_table, html
 from dash.dependencies import Input, Output
-from pymatgen.core import Structure
 
 import crystal_toolkit.components as ctc
 import crystal_toolkit.helpers.layouts as ctl
@@ -13,6 +14,9 @@ from crystal_toolkit.apps.examples.utils import (
     matbench_dielectric_desc,
 )
 from crystal_toolkit.settings import SETTINGS
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 pio.templates.default = "plotly_white"
 

--- a/crystal_toolkit/apps/examples/matbench_dielectric_structure_on_hover.py
+++ b/crystal_toolkit/apps/examples/matbench_dielectric_structure_on_hover.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import dash
 import plotly.express as px
 import plotly.io as pio
 from dash import dcc, html
 from dash.dependencies import Input, Output, State
-from pymatgen.core import Structure
 
 import crystal_toolkit.components as ctc
 from crystal_toolkit.apps.examples.utils import (
@@ -16,6 +15,9 @@ from crystal_toolkit.apps.examples.utils import (
 )
 from crystal_toolkit.helpers.utils import get_data_table
 from crystal_toolkit.settings import SETTINGS
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 pio.templates.default = "plotly_white"
 

--- a/crystal_toolkit/apps/examples/mpcontribs/catalysis.py
+++ b/crystal_toolkit/apps/examples/mpcontribs/catalysis.py
@@ -426,7 +426,7 @@ class CatalysisApp(MPApp):
             structure = client.get_structure(contribution["structures"][0]["id"])
         except Exception as ex:
             logger.error(ex)
-            raise PreventUpdate
+            raise PreventUpdate from ex
 
         bulk_formula = contribution["data"]["bulkFormula"]
         adsorbate_smiles = contribution["data"]["adsorbateSmiles"]

--- a/crystal_toolkit/apps/examples/tests/test_bandstructure.py
+++ b/crystal_toolkit/apps/examples/tests/test_bandstructure.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 from crystal_toolkit.apps.examples.bandstructure import app
-from crystal_toolkit.apps.examples.tests.typing import DashDuo
+
+if TYPE_CHECKING:
+    from crystal_toolkit.apps.examples.tests.typing import DashDuo
 
 
 def test_bs(dash_duo: DashDuo) -> None:

--- a/crystal_toolkit/apps/examples/tests/test_basic.py
+++ b/crystal_toolkit/apps/examples/tests/test_basic.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
 from crystal_toolkit.apps.examples.basic_hello_structure import (
     app as hello_structure_app,
@@ -9,7 +10,9 @@ from crystal_toolkit.apps.examples.basic_hello_structure_interactive import (
     app as hello_structure_interactive_app,
 )
 from crystal_toolkit.apps.examples.basic_hello_world import app as hello_world_app
-from crystal_toolkit.apps.examples.tests.typing import DashDuo
+
+if TYPE_CHECKING:
+    from crystal_toolkit.apps.examples.tests.typing import DashDuo
 
 
 def test_hello_scientist(dash_duo: DashDuo):

--- a/crystal_toolkit/apps/examples/tests/test_diffraction.py
+++ b/crystal_toolkit/apps/examples/tests/test_diffraction.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from time import sleep
+from typing import TYPE_CHECKING
 
 from selenium.webdriver.common.keys import Keys
 
 from crystal_toolkit.apps.examples.diffraction import app
-from crystal_toolkit.apps.examples.tests.typing import DashDuo
+
+if TYPE_CHECKING:
+    from crystal_toolkit.apps.examples.tests.typing import DashDuo
 
 
 def test_diffraction(dash_duo: DashDuo) -> None:

--- a/crystal_toolkit/apps/examples/tests/test_fermi_surface.py
+++ b/crystal_toolkit/apps/examples/tests/test_fermi_surface.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from crystal_toolkit.apps.examples.fermi_surface import app
-from crystal_toolkit.apps.examples.tests.typing import DashDuo
+
+if TYPE_CHECKING:
+    from crystal_toolkit.apps.examples.tests.typing import DashDuo
 
 
 def test_diffraction(dash_duo: DashDuo) -> None:

--- a/crystal_toolkit/apps/examples/tests/test_structure.py
+++ b/crystal_toolkit/apps/examples/tests/test_structure.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from time import sleep
+from typing import TYPE_CHECKING
 
 from crystal_toolkit.apps.examples.structure import app
-from crystal_toolkit.apps.examples.tests.typing import DashDuo
+
+if TYPE_CHECKING:
+    from crystal_toolkit.apps.examples.tests.typing import DashDuo
 
 
 def test_structure(dash_duo: DashDuo) -> None:

--- a/crystal_toolkit/apps/examples/tests/typing.py
+++ b/crystal_toolkit/apps/examples/tests/typing.py
@@ -11,6 +11,7 @@ class DashDuo(Protocol):
     """The dash_duo pytest fixture lives in dash.testing.plugin.dash_duo.
 
     See https://dash.plotly.com/testing#browser-apis
+    and https://github.com/plotly/dash/issues/2170
     """
 
     # driver = ...  # selenium.webdriver.remote.WebDriver

--- a/crystal_toolkit/apps/examples/utils.py
+++ b/crystal_toolkit/apps/examples/utils.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
-import pandas as pd
 from dash import dcc
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from tqdm import tqdm
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def load_and_store_matbench_dataset(dataset_name: str) -> pd.DataFrame:

--- a/crystal_toolkit/apps/main.py
+++ b/crystal_toolkit/apps/main.py
@@ -5,7 +5,7 @@ import os
 import warnings
 from random import choice
 from time import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib import parse
 from uuid import uuid4
 
@@ -22,7 +22,6 @@ from pymatgen.ext.matproj import MPRester, MPRestError
 import crystal_toolkit.components as ctc
 from crystal_toolkit import __file__ as module_path
 from crystal_toolkit.core.mpcomponent import MPComponent
-from crystal_toolkit.core.panelcomponent import PanelComponent
 from crystal_toolkit.helpers.layouts import (
     Box,
     Column,
@@ -35,6 +34,9 @@ from crystal_toolkit.helpers.layouts import (
     Reveal,
 )
 from crystal_toolkit.settings import SETTINGS
+
+if TYPE_CHECKING:
+    from crystal_toolkit.core.panelcomponent import PanelComponent
 
 # choose a default structure on load
 path = os.path.join(os.path.dirname(module_path), "apps/assets/task_ids_on_load.json")

--- a/crystal_toolkit/apps/tests/test_main.py
+++ b/crystal_toolkit/apps/tests/test_main.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import time
+from typing import TYPE_CHECKING
 
-from crystal_toolkit.apps.examples.tests.typing import DashDuo
 from crystal_toolkit.apps.main import app
+
+if TYPE_CHECKING:
+    from crystal_toolkit.apps.examples.tests.typing import DashDuo
 
 
 def test_main_app_startup(dash_duo: DashDuo):

--- a/crystal_toolkit/components/diffraction.py
+++ b/crystal_toolkit/components/diffraction.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import plotly.graph_objects as go
@@ -8,7 +9,6 @@ from dash import callback_context, dcc, html
 from dash.dependencies import Component, Input, Output
 from dash.exceptions import PreventUpdate
 from pymatgen.analysis.diffraction.xrd import WAVELENGTHS, XRDCalculator
-from pymatgen.core import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from scipy.special import wofz
 
@@ -21,6 +21,10 @@ from crystal_toolkit.helpers.layouts import (
     MessageBody,
     MessageContainer,
 )
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
+
 
 # Scherrer equation: Langford, J. Il, and A. J. C. Wilson. "Scherrer after sixty years:
 # a survey and some new results in the determination of crystallite size." Journal of

--- a/crystal_toolkit/components/diffraction_tem.py
+++ b/crystal_toolkit/components/diffraction_tem.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 from time import time
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
 import plotly.graph_objects as go
 from dash import dcc, html
 from dash.dependencies import Input, Output
-from pymatgen.core import Structure
 
 from crystal_toolkit.core.mpcomponent import MPComponent
 from crystal_toolkit.helpers.layouts import Box, Column, Columns, Loading, Reveal
+
+if TYPE_CHECKING:
+    from pymatgen.core import Structure
 
 try:
     import py4DSTEM

--- a/crystal_toolkit/components/fermi_surface.py
+++ b/crystal_toolkit/components/fermi_surface.py
@@ -4,12 +4,12 @@ import typing
 
 import matplotlib.pyplot as plt
 from dash import Input, Output
-from dash.development.base_component import Component
 
 from crystal_toolkit.core.mpcomponent import MPComponent
 from crystal_toolkit.helpers.layouts import Box, Column, Columns, Loading, dcc
 
 if typing.TYPE_CHECKING:
+    from dash.development.base_component import Component
     from ifermi.surface import FermiSurface
     from plotly.graph_objects import Figure
 

--- a/crystal_toolkit/components/phonon.py
+++ b/crystal_toolkit/components/phonon.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import plotly.graph_objects as go
@@ -9,8 +9,6 @@ from dash import dcc, html
 from dash.dependencies import Component, Input, Output
 from dash.exceptions import PreventUpdate
 from dash_mp_components import CrystalToolkitScene
-from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
-from pymatgen.electronic_structure.dos import CompleteDos
 from pymatgen.ext.matproj import MPRester
 from pymatgen.phonon.bandstructure import PhononBandStructureSymmLine
 from pymatgen.phonon.dos import CompletePhononDos
@@ -28,6 +26,10 @@ from crystal_toolkit.helpers.layouts import (
     get_data_list,
 )
 from crystal_toolkit.helpers.pretty_labels import pretty_labels
+
+if TYPE_CHECKING:
+    from pymatgen.electronic_structure.bandstructure import BandStructureSymmLine
+    from pymatgen.electronic_structure.dos import CompleteDos
 
 # Author: Jason Munro, Janosh Riebesell
 # Contact: jmunro@lbl.gov, janosh@lbl.gov

--- a/crystal_toolkit/core/legend.py
+++ b/crystal_toolkit/core/legend.py
@@ -4,7 +4,7 @@ import os
 import warnings
 from collections import defaultdict
 from itertools import chain
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from matplotlib.cm import get_cmap
@@ -13,10 +13,12 @@ from monty.serialization import loadfn
 from palettable.colorbrewer.qualitative import Set1_9
 from pymatgen.analysis.molecule_structure_comparator import CovalentRadius
 from pymatgen.core import Element, Molecule, Site, Species
-from pymatgen.core.structure import SiteCollection
 from pymatgen.util.string import unicodeify_species
 from sklearn.preprocessing import LabelEncoder
 from webcolors import html5_parse_legacy_color, html5_serialize_simple_color
+
+if TYPE_CHECKING:
+    from pymatgen.core.structure import SiteCollection
 
 # element colors forked from pymatgen
 module_dir = os.path.dirname(os.path.abspath(__file__))

--- a/crystal_toolkit/core/legend.py
+++ b/crystal_toolkit/core/legend.py
@@ -4,7 +4,7 @@ import os
 import warnings
 from collections import defaultdict
 from itertools import chain
-from typing import Any, cast
+from typing import Any
 
 import numpy as np
 from matplotlib.cm import get_cmap
@@ -131,7 +131,7 @@ class Legend(MSONable):
         self.color_scheme = color_scheme
         self.radius_scheme = radius_scheme
         self.cmap = cmap
-        self.cmap_range = cast(tuple[float, float], cmap_range)
+        self.cmap_range = cmap_range
 
     @staticmethod
     def generate_accessible_color_scheme_on_the_fly(

--- a/crystal_toolkit/core/mpcomponent.py
+++ b/crystal_toolkit/core/mpcomponent.py
@@ -8,12 +8,11 @@ from base64 import b64encode
 from collections import defaultdict
 from itertools import chain, zip_longest
 from json import JSONDecodeError, dumps, loads
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import dash
 import dash_mp_components as mpc
 import numpy as np
-import plotly.graph_objects as go
 from dash import dcc, html
 from dash.dependencies import ALL
 from flask_caching import Cache
@@ -22,6 +21,10 @@ from monty.json import MontyDecoder, MSONable
 from crystal_toolkit import __version__ as ct_version
 from crystal_toolkit.helpers.layouts import H6, Button, Icon, Loading, add_label_help
 from crystal_toolkit.settings import SETTINGS
+
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
+
 
 # fallback cache if Redis etc. isn't set up
 null_cache = Cache(config={"CACHE_TYPE": "null"})

--- a/crystal_toolkit/helpers/asymptote_renderer.py
+++ b/crystal_toolkit/helpers/asymptote_renderer.py
@@ -11,14 +11,16 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import chain
-from typing import IO, Any
+from typing import IO, TYPE_CHECKING, Any
 
 from jinja2 import Environment
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core import Structure
 
-from crystal_toolkit.core.scene import Scene
 from crystal_toolkit.defaults import _DEFAULTS
+
+if TYPE_CHECKING:
+    from crystal_toolkit.core.scene import Scene
 
 logger = logging.getLogger(__name__)
 

--- a/crystal_toolkit/helpers/asymptote_renderer.py
+++ b/crystal_toolkit/helpers/asymptote_renderer.py
@@ -596,12 +596,12 @@ def write_ctk_scene_to_file(ctk_scene, file_name, **kwargs):
         ctk_scene: Scene object from crystaltoolkit
         file_name: Output asymptote file and location
     """
-    fstream = open(file_name, "w")
     target = tuple(-ii for ii in ctk_scene.origin)
     header = Environment().from_string(HEADER).render(target=target)
-    fstream.write(header)
-    traverse_scene_object(ctk_scene, fstream, **kwargs)
-    fstream.close()
+
+    with open(file_name, "w") as fstream:
+        fstream.write(header)
+        traverse_scene_object(ctk_scene, fstream, **kwargs)
 
 
 def write_asy_file(renderable_object, file_name, **kwargs):

--- a/crystal_toolkit/helpers/povray_renderer.py
+++ b/crystal_toolkit/helpers/povray_renderer.py
@@ -205,17 +205,15 @@ def write_pov_file(smc, file_name):
     smc (StructureMoleculeComponent): Object containing the scene data.
     file_name (str): name of the file to write to.
     """
-    fstream = open(file_name, "w")
-    fstream.write(HEAD)
-    fstream.write(CAMERA)
-    fstream.write(LIGHTS)
-    filter_data(smc.initial_scene_data, fstream)
-    fstream.close()
+    with open(file_name, "w") as fstream:
+        fstream.write(HEAD)
+        fstream.write(CAMERA)
+        fstream.write(LIGHTS)
+        filter_data(smc.initial_scene_data, fstream)
 
-    fstream = open("render.ini", "w")
     render_settings = get_render_settings()
-    fstream.write(render_settings)
-    fstream.close()
+    with open(file_name, "w") as file:
+        file.write(render_settings)
 
 
 def get_render_settings(file_name):

--- a/crystal_toolkit/helpers/utils.py
+++ b/crystal_toolkit/helpers/utils.py
@@ -4,20 +4,17 @@ import logging
 import re
 import urllib.parse
 from fractions import Fraction
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 from uuid import uuid4
 
 import dash
 import dash_mp_components as mpc
 import numpy as np
-import pandas as pd
-import plotly.graph_objects as go
 from dash import Dash, dcc, html
 from dash import dash_table as dt
 from dash.dependencies import Input, Output, State
 from flask import has_request_context, request
 from monty.serialization import loadfn
-from numpy.typing import ArrayLike
 from pymatgen.core import Structure
 
 import crystal_toolkit.components as ctc
@@ -25,6 +22,11 @@ import crystal_toolkit.helpers.layouts as ctl
 from crystal_toolkit import MODULE_PATH
 from crystal_toolkit.defaults import _DEFAULTS
 from crystal_toolkit.settings import SETTINGS
+
+if TYPE_CHECKING:
+    import pandas as pd
+    import plotly.graph_objects as go
+    from numpy.typing import ArrayLike
 
 logger = logging.getLogger(__name__)
 

--- a/crystal_toolkit/renderables/site.py
+++ b/crystal_toolkit/renderables/site.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import Sequence
+from typing import TYPE_CHECKING, Sequence
 
 import numpy as np
-from pymatgen.analysis.graphs import ConnectedSite
 from pymatgen.core import Site
 from pymatgen.core.periodic_table import DummySpecie
 from pymatgen.electronic_structure.core import Magmom
@@ -20,6 +19,9 @@ from crystal_toolkit.core.scene import (
     Spheres,
     Surface,
 )
+
+if TYPE_CHECKING:
+    from pymatgen.analysis.graphs import ConnectedSite
 
 
 def get_site_scene(

--- a/crystal_toolkit/renderables/volumetric.py
+++ b/crystal_toolkit/renderables/volumetric.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from numpy.typing import ArrayLike
 from pymatgen.io.vasp import VolumetricData
 
 from crystal_toolkit.core.scene import Scene, Surface
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 _ANGS2_TO_BOHR3 = 1.88973**3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ select = [
     "C4",  # flake8-comprehensions
     "D",   # pydocstyle
     "E",   # pycodestyle error
+    "EXE", # flake8-executable
     "F",   # pyflakes
     "FLY", # flynt
     "I",   # isort
@@ -78,7 +79,9 @@ select = [
     "RSE", # flake8-raise
     "RUF", # Ruff-specific rules
     "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
     "TID", # tidy imports
+    "TID", # flake8-tidy-imports
     "UP",  # pyupgrade
     "W",   # pycodestyle warning
     "YTT", # flake8-2020

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ select = [
 ]
 ignore = [
     "B028",   # No explicit stacklevel keyword argument found
-    "B904",   # Within an except clause, raise exceptions with raise ... from err
     "C408",   # Unnecessary dict call - rewrite as a literal
     "D100",   # Missing docstring in public module
     "D104",   # Missing docstring in public package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,6 @@ ignore = [
     "PD901",  # pandas-df-variable-name
     "PLR",    # pylint refactor
     "SIM105", # Use contextlib.suppress(ValueError) instead of try-except-pass
-    "SIM115", # Use context handler for opening files
 ]
 pydocstyle.convention = "google"
 isort.split-on-trailing-comma = false


### PR DESCRIPTION
Thanks @samblau for reporting 

```py
crystal_toolkit/core/legend.py in __init__(self, site_collection, color_scheme, radius_scheme, cmap, cmap_range)
    132         self.radius_scheme = radius_scheme
    133         self.cmap = cmap
--> 134         self.cmap_range = cast(tuple[float, float], cmap_range)
    135 
    136     @staticmethod

TypeError: 'type' object is not subscriptable
```

on Python 3.9 and below. Fixed in https://github.com/materialsproject/crystaltoolkit/commit/9562b1826dda8990f753a8ea5db86668fba9097e. The rest are just linting changes.