### PR TITLE
Add `__str__`, `__repr__` to `StructureMoleculeComponent`

### DIFF
--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -86,7 +86,7 @@ class StructureMoleculeComponent(MPComponent):
         struct_or_mol: (
             None | Structure | StructureGraph | Molecule | MoleculeGraph
         ) = None,
-        id: str = None,
+        id: str | None = None,
         className: str = "box",
         scene_additions: Scene | None = None,
         bonding_strategy: str = DEFAULTS["bonding_strategy"],
@@ -237,6 +237,18 @@ class StructureMoleculeComponent(MPComponent):
             self.scene_kwargs = {"axisView": "HIDDEN"}
         else:
             self.scene_kwargs = {}
+
+    def __str__(self) -> str:
+        return repr(self)
+
+    def __repr__(self) -> str:
+        # TODO due to the current increment ID counter until unique, incl. component ID in the repr breaks unit tests
+        # consider adding ID to repr once ID creation is less brittle
+        # id = self._id
+        struct_or_mol = self._initial_data["default"]
+        formula = getattr(struct_or_mol, "formula", None)
+        atoms = getattr(struct_or_mol, "num_sites", None)
+        return f"StructureMoleculeComponent({formula=}, {atoms=})"
 
     def generate_callbacks(self, app, cache) -> None:
         # a lot of the verbosity in this callback is to support custom bonding

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,28 @@
+import pytest
+from pymatgen.core import Lattice, Molecule, Structure
+
+from crystal_toolkit.components.structure import StructureMoleculeComponent
+
+NaK = Structure(Lattice.cubic(4.2), ["Na", "K"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+
+water = Molecule(["O", "H", "H"], [[0, 0, 0], [0.7, 0.7, 0], [-0.7, 0.7, 0]])
+
+
+@pytest.mark.parametrize(
+    ("structure", "expected"),
+    [
+        (NaK, "StructureMoleculeComponent(formula='K1 Na1', atoms=2)"),
+        (water, "StructureMoleculeComponent(formula='H2 O1', atoms=3)"),
+    ],
+)
+def test_repr_with_struct_or_mol(structure, expected):
+    component = StructureMoleculeComponent(structure)
+    assert repr(component) == expected
+    assert str(component) == expected
+
+
+def test_repr_without_structure():
+    component = StructureMoleculeComponent()
+    expected = "StructureMoleculeComponent(formula=None, atoms=None)"
+    assert repr(component) == expected
+    assert str(component) == expected


### PR DESCRIPTION
 a71861b add __str__, __repr__ to StructureMoleculeComponent
 b856318 add unit tests test_repr_with_struct_or_mol(), test_repr_without_structure()

Minimal example:
```py
from pymatgen.core import Lattice, Structure
import crystal_toolkit.components as ctc

structure = Structure(Lattice.cubic(4.2), ["Na", "K"], [[0, 0, 0], [0.5, 0.5, 0.5]])

print(ctc.StructureMoleculeComponent(structure))
```

Before: `CTStructureMoleculeComponent-1<StructureMoleculeComponent>`
After: `StructureMoleculeComponent(formula='K1 Na1', atoms=2)`
