### PR TITLE
fix web ctk app structure transformation due to the component switch

### DIFF
--- a/crystal_toolkit/components/transformations/core.py
+++ b/crystal_toolkit/components/transformations/core.py
@@ -54,6 +54,7 @@ class TransformationComponent(MPComponent):
             # style used to be passed to dash_daq.ToggleSwitch component, but not
             # supported by mpc.Switch
             # style={"display": "inline-block", "vertical-align": "middle"},
+            value=False
         )
 
         message = html.Div(id=self.id("message"))
@@ -214,7 +215,7 @@ class TransformationComponent(MPComponent):
             Output(self.id("container"), "className"),
             Output(self.id("message"), "children"),
             Output(self.get_all_kwargs_id(), "disabled"),
-            Input(self.id("enable_transformation"), "on"),
+            Input(self.id("enable_transformation"), "value"),
             State(self.get_all_kwargs_id(), "value"),
         )
         @cache.memoize(

--- a/crystal_toolkit/components/transformations/core.py
+++ b/crystal_toolkit/components/transformations/core.py
@@ -54,7 +54,7 @@ class TransformationComponent(MPComponent):
             # style used to be passed to dash_daq.ToggleSwitch component, but not
             # supported by mpc.Switch
             # style={"display": "inline-block", "vertical-align": "middle"},
-            value=False
+            value=False,
         )
 
         message = html.Div(id=self.id("message"))


### PR DESCRIPTION
Hi @janosh the change in [PR #333](https://github.com/materialsproject/crystaltoolkit/pull/333) is causing the web ctk app to not function properly, see [post](https://matsci.org/t/crystal-toolkit-does-not-work/48878). The issue is when you change the `BooleanSwitch` to the `mpc.Switch`, you didn't change the corresponding prop in the callbacks. 
Would you carefully check if this change has impacted other parts of ctk and/or the web? And then we could do a release. Thanks! 