### PR TITLE
revert the color map change from dd4f8c

### DIFF
--- a/crystal_toolkit/core/legend.py
+++ b/crystal_toolkit/core/legend.py
@@ -111,7 +111,7 @@ class Legend(MSONable):
                 for p in site_collection.site_properties[color_scheme]
                 if p is not None
             ]
-            prop_max = max(*min(props), *props)
+            prop_max = max(abs(min(props)), max(props))
             prop_min = -prop_max
             cmap_range = (prop_min, prop_max)
 


### PR DESCRIPTION
This is to revert the unexpected behavior caused by the change in dd4f8c 
