### PR TITLE
remove robocrys from component __init__.py

### DIFF
--- a/crystal_toolkit/apps/main.py
+++ b/crystal_toolkit/apps/main.py
@@ -22,7 +22,6 @@ from pymatgen.ext.matproj import MPRester, MPRestError
 import crystal_toolkit.components as ctc
 from crystal_toolkit import __file__ as module_path
 from crystal_toolkit.core.mpcomponent import MPComponent
-from crystal_toolkit.components.robocrys import RobocrysComponent
 from crystal_toolkit.helpers.layouts import (
     Box,
     Column,

--- a/crystal_toolkit/apps/main.py
+++ b/crystal_toolkit/apps/main.py
@@ -22,6 +22,7 @@ from pymatgen.ext.matproj import MPRester, MPRestError
 import crystal_toolkit.components as ctc
 from crystal_toolkit import __file__ as module_path
 from crystal_toolkit.core.mpcomponent import MPComponent
+from crystal_toolkit.components.robocrys import RobocrysComponent
 from crystal_toolkit.helpers.layouts import (
     Box,
     Column,

--- a/crystal_toolkit/components/__init__.py
+++ b/crystal_toolkit/components/__init__.py
@@ -17,7 +17,6 @@ from crystal_toolkit.components.phonon import (
     PhononBandstructureAndDosPanelComponent,
 )
 from crystal_toolkit.components.pourbaix import PourbaixDiagramComponent
-from crystal_toolkit.components.robocrys import RobocrysComponent
 from crystal_toolkit.components.search import SearchComponent
 from crystal_toolkit.components.structure import StructureMoleculeComponent
 


### PR DESCRIPTION
this causes errors when import ctc.component because robocrys is an optional dependency

