### PR TITLE
`StructureMoleculeComponent` use `"material_id"` or `"id"` in image filename if found in `Structure.properties`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,11 @@ exclude: ^(docs/.+|.*lock.*|jupyterlab-extension/.+|.*\.(svg|js|css))|_version.p
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.5
     hooks:
       - id: ruff
         args: [--fix, --ignore, D]
-
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black-jupyter
+      - id: ruff-format
 
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v1.3.0
@@ -41,7 +37,7 @@ repos:
     hooks:
       - id: codespell
         stages: [commit, commit-msg]
-        args: [--ignore-words-list, "nd,te,ois,dscribe"]
+        args: [--ignore-words-list, "nd,te,ois,dscribe", --check-filenames]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.6.1

--- a/crystal_toolkit/apps/examples/mpcontribs/catalysis.py
+++ b/crystal_toolkit/apps/examples/mpcontribs/catalysis.py
@@ -293,7 +293,7 @@ class CatalysisApp(MPApp):
             show_compass=False,
             show_settings=False,
             show_image_button=False,
-            show_export_button=False
+            show_export_button=False,
             # group_by_site_property="display_text",  # pending new Crystal Toolkit release
         ).layout()
 

--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -460,7 +460,12 @@ class StructureMoleculeComponent(MPComponent):
             spg_symbol = getattr(struct_or_mol, "get_space_group_info", lambda: [""])()[
                 0
             ]
-            request_filename = f"{formula}-{spg_symbol}-crystal-toolkit.png"
+            request_filename = f"{formula}-{spg_symbol}.png"
+            material_id = struct_or_mol.properties.get(
+                "material_id", struct_or_mol.properties.get("id")
+            )
+            if material_id:
+                request_filename = f"{material_id}-{request_filename}"
 
             return {
                 "content": image_data[len("data:image/png;base64,") :],


### PR DESCRIPTION
4b8d4d5 drop black for ruff format
47e4305 `StructureMoleculeComponent` use "material_id" or "id" in image filename if found in `Structure.properties`