### PR TITLE
Patch wf

### DIFF
--- a/.github/workflows/pytest-docs.yml
+++ b/.github/workflows/pytest-docs.yml
@@ -1,9 +1,14 @@
 name: Build Docs
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -36,7 +41,7 @@ jobs:
           cd docs_rst
           make html
       - name: Detect changes
-        if: contains(github.ref, 'refs/heads/main')
+        if: ${{ !contains(github.ref, 'refs/heads/main') }}
         id: changes
         shell: bash
         run: |

--- a/.github/workflows/pytest-docs.yml
+++ b/.github/workflows/pytest-docs.yml
@@ -1,14 +1,7 @@
 name: Build Docs
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
-  pull_request:
-    branches:
-      - main
+  [release, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pytest-docs.yml
+++ b/.github/workflows/pytest-docs.yml
@@ -1,14 +1,9 @@
 name: Build Docs
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
-  pull_request:
-    branches:
-      - main
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Docs workflow cannot run on `main` or as part of PR,  must be executed manually for now.

Should consider moving docs to `gh_pages` branch. 