### PR TITLE
Add Docs to PR WF

### DIFF
--- a/.github/workflows/pytest-docs.yml
+++ b/.github/workflows/pytest-docs.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches:
       - main
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -40,8 +42,8 @@ jobs:
         run: |
           cd docs_rst
           make html
-      - name: Detect changes
-        if: ${{ contains(github.ref, 'refs/heads/main') }}
+      - name: Detect changes on release
+        if: startsWith(github.head_ref, 'releases/')
         id: changes
         shell: bash
         run: |

--- a/.github/workflows/pytest-docs.yml
+++ b/.github/workflows/pytest-docs.yml
@@ -1,7 +1,14 @@
 name: Build Docs
 
 on:
-  [release, workflow_dispatch]
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -34,6 +41,7 @@ jobs:
           cd docs_rst
           make html
       - name: Detect changes
+        if: ${{ contains(github.ref, 'refs/heads/main') }}
         id: changes
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
         run: pip install build
 
       - name: Publish package
-        if: contains(github.ref, 'refs/heads/main')
         uses: pypa/gh-action-pypi-publish@release/v1.5
         with:
           user: __token__


### PR DESCRIPTION
# Further fixes to wfs
Originally,  the docs workflow does not trigger on PR.

Now it should do everything other than writing to the repo during the PR.
During releases, it should write to the release branch.

