### PR TITLE
fix get_cmap import

### DIFF
--- a/crystal_toolkit/core/legend.py
+++ b/crystal_toolkit/core/legend.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from itertools import chain
 from typing import TYPE_CHECKING, Any
 
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 from monty.json import MSONable
 from monty.serialization import loadfn
 from palettable.colorbrewer.qualitative import Set1_9

--- a/crystal_toolkit/renderables/structuregraph.py
+++ b/crystal_toolkit/renderables/structuregraph.py
@@ -5,7 +5,7 @@ from itertools import combinations
 from typing import Sequence
 
 import numpy as np
-from matplotlib.cm import get_cmap
+from matplotlib.pyplot import get_cmap
 from pymatgen.analysis.graphs import StructureGraph
 from pymatgen.core import PeriodicSite
 


### PR DESCRIPTION
matplotlib 3.9.0 removes `matplotlib.cm.get_cmap` but `matplotlib.pyplot.get_cmap` remains available for backward compatibility. See [here](https://github.com/matplotlib/matplotlib/blob/31a2e1edb756e6b42ecd7ff405e488647d8ea27a/doc/api/prev_api_changes/api_changes_3.9.0/removals.rst#top-level-cmap-registration-and-access-functions-in-mplcm). Just changing the import might work, but if not, we might have to change the logic to use the `matplotlib.colormaps` dict.