### PR TITLE
Add loading screen for crystal visualization

### DIFF
--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -25,7 +25,7 @@ from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from crystal_toolkit.core.legend import Legend
 from crystal_toolkit.core.mpcomponent import MPComponent
 from crystal_toolkit.core.scene import Scene
-from crystal_toolkit.helpers.layouts import H2, Field, dcc, html
+from crystal_toolkit.helpers.layouts import H2, Field, dcc, html, Loading
 from crystal_toolkit.settings import SETTINGS
 
 # TODO: make dangling bonds "stubs"? (fixed length)
@@ -887,7 +887,7 @@ class StructureMoleculeComponent(MPComponent):
         )
 
         return {
-            "struct": struct_layout,
+            "struct": Loading(struct_layout),
             "options": options_layout,
             "title": title_layout,
             "legend": legend_layout,


### PR DESCRIPTION
Meant to implement a loading screen for the crystal visualization tool in place of the blank screen. 

Using Loading() with no further changes results in a loading screen that is preceded by a blank white screen for longer loading times. 