### PR TITLE
Move `crystaltoolkit-extension` into new optional deps set `"extension"`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.9"
 authors = [{ name = "Matt Horton", email = "mkhorton@lbl.gov" }]
 
 dependencies = [
-    "crystaltoolkit-extension",
     "dash-mp-components>=0.4.38",
     "dash>=2.11.0",
     "flask-caching",
@@ -44,6 +43,7 @@ dev = [
     "sphinx_rtd_theme",
 ]
 test = ["playwright", "pytest", "pytest-playwright", "pytest-cov"]
+extension = ["crystaltoolkit-extension"]
 
 [project.urls]
 repo = "https://github.com/materialsproject/crystaltoolkit"


### PR DESCRIPTION
avoids `ModuleNotFoundError: No module named 'pipes'` when running `pip install crystal_toolkit`

addresses #445 