### PR TITLE
remove unsupported verbose kwarg

### DIFF
--- a/crystal_toolkit/components/diffraction_tem.py
+++ b/crystal_toolkit/components/diffraction_tem.py
@@ -325,7 +325,6 @@ class TEMDiffractionCalculator:
             k_max=self.k_max,
             thermal_sigma=DWF,
             recompute_kinematic_structure_factors=False,
-            verbose=False,
         )
 
         self.dynamical_method = dynamical_method


### PR DESCRIPTION
Fix: remove unsupported verbose kwarg in TEM diffraction path

<br>

Issue
Generating a TEM diffraction pattern raised:
`TypeError: calculate_dynamical_structure_factors() got an unexpected keyword argument 'verbose'`

<br>

Root cause:
`Crystal.calculate_dynamical_structure_factors` does not accept `verbose`. Current signature:
```
def calculate_dynamical_structure_factors(
    self,
    accelerating_voltage: float,
    method: str = "WK-CP",
    k_max: float = 2.0,
    thermal_sigma: Optional[Union[float, dict]] = None,
    tol_structure_factor: float = 0.0,
    recompute_kinematic_structure_factors=True,
    g_vec_precision=None,
):
```

<br>

Change:
Remove the `verbose` keyword at the call site in `crystal_toolkit/components/diffraction_tem.py` (inside `update_dynamic_structure_factors`).