### PR TITLE
correct name  mapping to BrunnerNNReciprocal

### DIFF
--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -688,7 +688,7 @@ class StructureMoleculeComponent(MPComponent):
             "Minimum Distance (10% tolerance)": "MinimumDistanceNN",
             "O'Keeffe's Algorithm": "MinimumOKeeffeNN",
             "Hoppe's ECoN Algorithm": "EconNN",
-            "Brunner's Reciprocal Algorithm": "BrunnerNN_reciprocal",
+            "Brunner's Reciprocal Algorithm": "BrunnerNNReciprocal",
         }
 
         bonding_algorithm = dcc.Dropdown(


### PR DESCRIPTION
Fixed an error that occurred when selecting `Brunner’s Reciprocal Algorithm` under `Change bonding algorithm`.

Error (local)
```
  File "/usr/local/lib/python3.11/site-packages/crystal_toolkit/components/structure.py", line 972, in _preprocess_input_to_graph
    raise ValueError(
ValueError: Bonding strategy not supported. Please supply a name of a NearNeighbor subclass, choose from: VoronoiNN, JmolNN, MinimumDistanceNN, OpenBabelNN, CovalentBondNN, MinimumOKeeffeNN, MinimumVIRENN, BrunnerNNReciprocal, BrunnerNNRelative, BrunnerNNReal, EconNN, CrystalNN, CutOffDictNN, Critic2NN
```

Root cause:
Incorrect name mapping for the bonding strategy.

Fix:
```
- "Brunner's Reciprocal Algorithm": "BrunnerNN_Reciprocal",
+ "Brunner's Reciprocal Algorithm": "BrunnerNNReciprocal",
```

Open question:
The error message appears locally but not in production. The underlying cause of the missing production error message still needs investigation.


