### PR TITLE
add ipython to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "scikit-learn",
   "shapely",
   "webcolors",
+  "ipython"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Issue:
```
Traceback (most recent call last):
  File "/Users/minhsuehchiu/Downloads/test/test.py", line 1, in <module>
    import crystal_toolkit
  File "/Users/minhsuehchiu/Downloads/test/.venv/lib/python3.11/site-packages/crystal_toolkit/__init__.py", line 9, in <module>
    from crystal_toolkit.core.jupyter import patch_msonable
  File "/Users/minhsuehchiu/Downloads/test/.venv/lib/python3.11/site-packages/crystal_toolkit/core/jupyter.py", line 10, in <module>
    from IPython.display import JSON, publish_display_data
ModuleNotFoundError: No module named 'IPython'
```

Fix:
Add `ipython` to `pyproject.toml` dependencies