### PR TITLE
fix download with different unit cell types

### DIFF
--- a/crystal_toolkit/components/structure.py
+++ b/crystal_toolkit/components/structure.py
@@ -489,7 +489,7 @@ class StructureMoleculeComponent(MPComponent):
             Output(self.id("download-structure"), "data"),
             Input(self.id("scene"), "fileTimestamp"),
             State(self.id("scene"), "fileType"),
-            State(self.id(), "data"),
+            State(self.id("graph"), "data"),
         )
         def download_structure(file_timestamp, download_option, data):
             if not file_timestamp:


### PR DESCRIPTION
Bug fix for the [report.](https://matsci.org/t/primitive-cell-any-way-to-access/66995)
> Download options –> the crystal viewer gives 6 download options, ALL of them are the conventional cell.

Root cause:
```
State(self.id(), "data"),
```
The original code uses the structure from the Docs, which is why the downloaded structures are the same every time.

Fix:
```
State(self.id("graph"), "data"),
```
Use the current generated graph data, which has been modified with the user's desired `graph_generation_options.`