### PR TITLE
optimize messageAIO usage

### DIFF
--- a/crystal_toolkit/components/messageAIO.py
+++ b/crystal_toolkit/components/messageAIO.py
@@ -291,26 +291,18 @@ class MessageAIO(html.Div, MPComponent):
     """
 
     @callback(
-        Output(ids.wrapper(MATCH), "style", allow_duplicate=True),
-        Input(ids.close_button(MATCH), "n_clicks"),
-        prevent_initial_call=True,
-    )
-    def sync_message(close_clicks):
-        return {"display": "none"}
-
-    @callback(
         Output(ids.message(MATCH), "children"),
         Output(ids.wrapper(MATCH), "style", allow_duplicate=True),
         Output(ids.div(MATCH), "style"),
+        Output(ids.close_button(MATCH), "n_clicks"),
         Input(ids.data(MATCH), "data"),
-        Input(ids.wrapper(MATCH), "style"),
+        Input(ids.close_button(MATCH), "n_clicks"),
         State(ids.div(MATCH), "style"),
         prevent_initial_call=True,
     )
-    def update_messages(input_data, cur_wrapper_style, cur_style):
-        print(input_data)
-        if not input_data:
-            return no_update, {"display": "none"}, cur_style
+    def update_messages(input_data, close_clicks, cur_style):
+        if close_clicks or not input_data:
+            return no_update, {"display": "none"}, cur_style, 0
 
         message = input_data.get("message", None)
         msg_type = input_data.get("msg_type", "info")
@@ -319,7 +311,7 @@ class MessageAIO(html.Div, MPComponent):
         type_style = _TYPE_COLORS.get(msg_type, _TYPE_COLORS["info"])
         cur_style.update(type_style)
 
-        return message, {"display": "block"}, cur_style
+        return message, {"display": "block"}, cur_style, 1
 
     """
     @callback(

--- a/crystal_toolkit/components/messageAIO.py
+++ b/crystal_toolkit/components/messageAIO.py
@@ -1,32 +1,39 @@
 """
-Author: Sheng Pang
-Modifier: Min-Hsueh Chiu
+Authors: Sheng Pang & Min-Hsueh Chiu
 
-Message Snake - A reusable Dash notification snackbar component.
-
+messageAIO - A reusable Dash notification snackbar component.
 Provides fixed-position toast notifications callable from any page.
-Supports fade-in/fade-out animations, auto-dismiss, and manual close.
+Supports fade-in/fade-out animations (not implemented), auto-dismiss (not implemented), and manual close.
+
+
+V1: The instantiated messageAIO is limited to one single `msg_type`.
+
+So it becomes difficult to use when an app has multiple msg_types.
+Developers would need to instantiate multiple MessageAIO components and
+define multiple Outputs in the callback.
+
+V2 improvement:
+- use a single instantiation and only one Output per callback.
+- If `ids.data` is change, then it should be visible, this logic should be handled here.
+
+
 
 Usage:
     from crystal_toolkit.components.error_msg import MessageAIO
 
     # 1. Include in layout
-    MessageAIO(
-        "Invalid composition input!",
-        aio_id=self.id("invalid-comp-alarm"),
-        msg_type="error",
-    ),
+    MessageAIO(aio_id=self.id(<COMPONENT_ID>)),
 
     # 2. Add to callback:
-    Output(MessageAIO.ids.visible(self.id("invalid-comp-alarm")), "data"),
-    # Return True to display the message, and False to hide it.
+    Output(MessageAIO.ids.data(self.id(<COMPONENT_ID>)), "data"),
+    Return {"message": <DISPLAY MSG>, "msg_type": <MSG_TYPE>}
 
     Note: Do not need to register callbacks as using All-in-one pattern
 """
 
 from __future__ import annotations
 
-from dash import MATCH, Input, Output, callback, ctx, dcc, html
+from dash import MATCH, Input, Output, State, callback, dcc, html, no_update
 
 from crystal_toolkit.core.mpcomponent import MPComponent
 
@@ -106,11 +113,6 @@ class MessageAIO(html.Div, MPComponent):
             "subcomponents": "close_button",
             "aio_id": aio_id,
         }
-        message = lambda aio_id: {
-            "component": "MessageAIO",
-            "subcomponents": "message",
-            "aio_id": aio_id,
-        }
         div = lambda aio_id: {
             "component": "MessageAIO",
             "subcomponents": "div",
@@ -121,9 +123,14 @@ class MessageAIO(html.Div, MPComponent):
             "subcomponents": "timer",
             "aio_id": aio_id,
         }
-        visible = lambda aio_id: {
+        data = lambda aio_id: {
             "component": "MessageAIO",
-            "subcomponents": "visible",
+            "subcomponents": "data",
+            "aio_id": aio_id,
+        }
+        message = lambda aio_id: {
+            "component": "MessageAIO",
+            "subcomponents": "message",
             "aio_id": aio_id,
         }
 
@@ -133,9 +140,7 @@ class MessageAIO(html.Div, MPComponent):
 
     def __init__(
         self,
-        message,
         aio_id,
-        msg_type,
         position="bottom-right",
         style=None,
         show_icon=False,
@@ -151,29 +156,22 @@ class MessageAIO(html.Div, MPComponent):
         to enable auto-dismiss and close functionality.
 
         Args:
-            message (str): The notification message to display.
             id (str): Unique HTML id for the notification container.
-            msg_type (str): Notification type - 'info', 'warning', 'error', 'success'.
-            position (str): Fixed position on screen. One of:
+            position (str, optional): Fixed position on screen. One of:
                 'top', 'bottom', 'center', 'top-right', 'top-left',
                 'bottom-right', 'bottom-left'.
             style (dict, optional): Additional CSS style overrides.
-            show_icon (bool): Whether to show a type-specific icon.
-            min_width (str): Minimum width of the notification.
-            max_width (str): Maximum width of the notification.
-            z_index (int): CSS z-index for layering.
-            auto_dismiss_ms (int): Auto-dismiss delay in milliseconds. Defaults to 50000 (50s).
+            show_icon (bool, optional): Whether to show a type-specific icon.
+            min_width (str, optional): Minimum width of the notification.
+            max_width (str, optional): Maximum width of the notification.
+            z_index (int, optional): CSS z-index for layering.
+            auto_dismiss_ms (int, optional): Auto-dismiss delay in milliseconds. Defaults to 50000 (50s).
 
         """
 
         self.snake_id = aio_id
         self.show_icon = show_icon
-        self.msg_type = msg_type
-        self.message = message
         self.auto_dismiss_ms = auto_dismiss_ms
-
-        # Resolve type colors
-        type_style = _TYPE_COLORS.get(msg_type, _TYPE_COLORS["info"])
 
         # Resolve position
         pos_style = _POSITION_STYLES.get(position, _POSITION_STYLES["bottom-right"])
@@ -197,7 +195,6 @@ class MessageAIO(html.Div, MPComponent):
             # Visible on mount; fade-out handled by callback via transition
             "opacity": "1",
             "transition": "opacity 0.4s ease",
-            **type_style,
             **pos_style,
         }
 
@@ -210,7 +207,10 @@ class MessageAIO(html.Div, MPComponent):
         sub_layouts = self._sub_layouts
         super().__init__(
             [  # Equivalent to `html.Div([...])`
-                dcc.Store(id=self.ids.visible(self.snake_id), data=False),
+                dcc.Store(
+                    id=self.ids.data(self.snake_id),
+                    data={"message": None, "msg_type": "info"},
+                ),
                 sub_layouts["notification_div"],
                 sub_layouts["interval"],
             ],
@@ -235,9 +235,7 @@ class MessageAIO(html.Div, MPComponent):
 
         # Message text
         children.append(
-            html.Span(
-                self.message, id=self.ids.message(self.snake_id), style={"flex": "1"}
-            )
+            html.Span(id=self.ids.message(self.snake_id), style={"flex": "1"})
         )
 
         # Close button
@@ -293,21 +291,35 @@ class MessageAIO(html.Div, MPComponent):
     """
 
     @callback(
-        Output(ids.wrapper(MATCH), "style"),
-        Input(ids.visible(MATCH), "data"),
+        Output(ids.wrapper(MATCH), "style", allow_duplicate=True),
         Input(ids.close_button(MATCH), "n_clicks"),
         prevent_initial_call=True,
     )
-    def sync_message(command_visible, close_clicks):
-        triggered = ctx.triggered_id
+    def sync_message(close_clicks):
+        return {"display": "none"}
 
-        if (
-            isinstance(triggered, dict)
-            and triggered.get("subcomponents") == "close_button"
-        ):
-            return {"display": "none"}
+    @callback(
+        Output(ids.message(MATCH), "children"),
+        Output(ids.wrapper(MATCH), "style", allow_duplicate=True),
+        Output(ids.div(MATCH), "style"),
+        Input(ids.data(MATCH), "data"),
+        Input(ids.wrapper(MATCH), "style"),
+        State(ids.div(MATCH), "style"),
+        prevent_initial_call=True,
+    )
+    def update_messages(input_data, cur_wrapper_style, cur_style):
+        print(input_data)
+        if not input_data:
+            return no_update, {"display": "none"}, cur_style
 
-        return {"display": "block"} if command_visible else {"display": "none"}
+        message = input_data.get("message", None)
+        msg_type = input_data.get("msg_type", "info")
+
+        # Resolve type colors
+        type_style = _TYPE_COLORS.get(msg_type, _TYPE_COLORS["info"])
+        cur_style.update(type_style)
+
+        return message, {"display": "block"}, cur_style
 
     """
     @callback(

--- a/crystal_toolkit/components/messageAIO.py
+++ b/crystal_toolkit/components/messageAIO.py
@@ -33,9 +33,13 @@ Usage:
 
 from __future__ import annotations
 
-from dash import MATCH, Input, Output, State, callback, dcc, html, no_update
+import logging
+
+from dash import MATCH, Input, Output, State, callback, ctx, dcc, html, no_update
 
 from crystal_toolkit.core.mpcomponent import MPComponent
+
+logger = logging.getLogger(__name__)
 
 # Bulma-inspired color scheme for notification types
 _TYPE_COLORS = {
@@ -294,24 +298,39 @@ class MessageAIO(html.Div, MPComponent):
         Output(ids.message(MATCH), "children"),
         Output(ids.wrapper(MATCH), "style", allow_duplicate=True),
         Output(ids.div(MATCH), "style"),
-        Output(ids.close_button(MATCH), "n_clicks"),
         Input(ids.data(MATCH), "data"),
         Input(ids.close_button(MATCH), "n_clicks"),
         State(ids.div(MATCH), "style"),
         prevent_initial_call=True,
     )
     def update_messages(input_data, close_clicks, cur_style):
-        if close_clicks or not input_data:
-            return no_update, {"display": "none"}, cur_style, 0
+        if not isinstance(input_data, dict):
+            raise ValueError("`input_data` must be a dictionary for MessageAIO")
+
+        if (
+            isinstance(ctx.triggered_id, dict)
+            and ctx.triggered_id.get("subcomponents") == "close_button"
+        ):
+            return no_update, {"display": "none"}, cur_style
+
+        if not input_data:
+            return no_update, {"display": "none"}, cur_style
 
         message = input_data.get("message", None)
-        msg_type = input_data.get("msg_type", "info")
+        msg_type = input_data.get("msg_type", None)
+
+        if not message:
+            raise ValueError("`message` field is required for MessageAIO")
+
+        if not msg_type:
+            logger.warning("No `msg_type`. Falling back to 'info'")
+            msg_type = "info"
 
         # Resolve type colors
-        type_style = _TYPE_COLORS.get(msg_type, _TYPE_COLORS["info"])
+        type_style = _TYPE_COLORS.get(msg_type, {})
         cur_style.update(type_style)
 
-        return message, {"display": "block"}, cur_style, 1
+        return message, {"display": "block"}, cur_style
 
     """
     @callback(

--- a/crystal_toolkit/components/pourbaix.py
+++ b/crystal_toolkit/components/pourbaix.py
@@ -460,14 +460,7 @@ class PourbaixDiagramComponent(MPComponent):
                 html.Div(
                     [
                         MessageAIO(
-                            "Invalid composition input!",
-                            aio_id=self.id("invalid-comp-alarm"),
-                            msg_type="error",
-                        ),
-                        MessageAIO(
-                            "Invalid concentration input!",
-                            aio_id=self.id("invalid-conc-alarm"),
-                            msg_type="error",
+                            aio_id=self.id("outputConsole"),
                         ),
                         html.Div(
                             [
@@ -796,8 +789,8 @@ class PourbaixDiagramComponent(MPComponent):
 
         @app.callback(
             Output(self.id("graph-panel"), "children"),
-            Output(MessageAIO.ids.visible(self.id("invalid-comp-alarm")), "data"),
-            Output(MessageAIO.ids.visible(self.id("invalid-conc-alarm")), "data"),
+            Output(MessageAIO.ids.data(self.id("outputConsole")), "data"),
+            # Output(MessageAIO.ids.visible(self.id("invalid-conc-alarm")), "data"),
             Output(self.id("display-composition"), "children"),
             Input(self.id(), "data"),
             Input(self.id("display-composition"), "children"),
@@ -836,8 +829,7 @@ class PourbaixDiagramComponent(MPComponent):
                 logger.error("Invalid composition input!")
                 return (
                     self.get_figure_div(),
-                    True,
-                    False,
+                    {"message": "Invalid composition input!", "msg_type": "error"},
                     "",
                 )
             try:
@@ -853,8 +845,7 @@ class PourbaixDiagramComponent(MPComponent):
                 logger.error("Invalid composition input!")
                 return (
                     self.get_figure_div(),
-                    True,
-                    False,
+                    {"message": "Invalid composition input!", "msg_type": "error"},
                     "",
                 )
 
@@ -889,8 +880,10 @@ class PourbaixDiagramComponent(MPComponent):
                         # if the input is out of pre-defined range, Input will get None
                         return (
                             self.get_figure_div(),
-                            False,
-                            True,
+                            {
+                                "message": "Invalid concentration input!",
+                                "msg_type": "error",
+                            },
                             "",
                         )
 
@@ -919,7 +912,6 @@ class PourbaixDiagramComponent(MPComponent):
 
             return (
                 self.get_figure_div(figure=figure),
-                False,
-                False,
+                {},
                 html.Small(f"Pourbaix composition set to {unicodeify(formula)}."),
             )

--- a/crystal_toolkit/components/pourbaix.py
+++ b/crystal_toolkit/components/pourbaix.py
@@ -790,7 +790,6 @@ class PourbaixDiagramComponent(MPComponent):
         @app.callback(
             Output(self.id("graph-panel"), "children"),
             Output(MessageAIO.ids.data(self.id("outputConsole")), "data"),
-            # Output(MessageAIO.ids.visible(self.id("invalid-conc-alarm")), "data"),
             Output(self.id("display-composition"), "children"),
             Input(self.id(), "data"),
             Input(self.id("display-composition"), "children"),


### PR DESCRIPTION
### V1: The instantiated `MessageAIO` is limited to a single `msg_type`

This makes it difficult to use in applications with multiple message types, as developers need to instantiate multiple `MessageAIO` components and define multiple Outputs in the callback.

### V2 improvement:
- Use a single `MessageAIO` per app/page
- Require only one Output per callback
- Automatically handle visibility: when `MessageAIO.ids.data` changes, the message should be shown by default

Example using the Pourbaix component:

Layout:
```
                        MessageAIO(
                            aio_id=self.id("outputConsole"),
                        ),
```

Callback:
```
        @app.callback(
            Output(MessageAIO.ids.data(self.id("outputConsole")), "data"),
            ...
       )
       def make_figure(...):
            return {"message": "Invalid composition input!", "msg_type": "error"},
```