### PR TITLE
reorder build-system and project in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2,<8"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "crystal_toolkit"
 dynamic = ["version"]
@@ -68,10 +72,6 @@ exclude = ["docs_rst"]
 write_to = "crystal_toolkit/_version.py"
 write_to_template = '__version__ = "{version}"'
 local_scheme = "no-local-version"
-
-[build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2,<8"]
-build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 target-version = "py38"


### PR DESCRIPTION
Fix [Dependabot](https://github.com/materialsproject/crystaltoolkit/actions/runs/25945486643) fail. 

```
updater | 2026/05/15 23:02:47 ERROR <job_1369807079> Error processing job (Dependabot::DependabotError)
2026/05/15 23:02:47 ERROR <job_1369807079> No supported dependency file present.
```

From Claude Haiku4.5:
```
The Real Culprit: Dependabot/GitHub Updated Their Parser
Since May 8-9, 2026, GitHub likely updated their Dependabot dependency grapher to be more strict with:

TOML parsing rules
PEP 621 compliance validation
Python dependency file detection logic
This is a Dependabot service-side change, not something you did.
```

Fix: 
Reordering the pyproject for the parser, aligning with modern PEP compliance validation. 